### PR TITLE
Check if a Config message was handled before creating first tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -554,12 +554,13 @@ impl Application for App {
                             .closable()
                             .activate()
                             .id();
-                        let terminal = Terminal::new(
+                        let mut terminal = Terminal::new(
                             entity,
                             term_event_tx.clone(),
                             self.term_config.clone(),
                             colors.clone(),
                         );
+                        terminal.set_config(&self.config, &self.themes);
                         self.tab_model
                             .data_set::<Mutex<Terminal>>(entity, Mutex::new(terminal));
                     }


### PR DESCRIPTION
In `Application::subscription()`, `subscription::channel()` would
 create a dead terminal tab if it was called before
 `config_subscription()`.

 Then `subscription::channel()` would be triggered a second time
 creating a second terminal tab that works.

 This commit fixes this issue by only creating the first terminal
 tab after a `Message::Config{}` was handled, i.e. after
 `config_subscription()` was run.

----

Includes commit from #19.