### PR TITLE
Configurable font stretch, font weight, and bold font weight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "lazy_static",
  "libcosmic",
  "log",
+ "paste",
  "rust-embed",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["sync"] }
 i18n-embed = { version = "0.13", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.6"
 rust-embed = "6"
+paste = "1.0"
 
 [dependencies.cosmic-text]
 git = "https://github.com/pop-os/cosmic-text.git"

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -12,6 +12,9 @@ light = Light
 syntax-dark = Syntax dark
 syntax-light = Syntax light
 default-font = Default font
+default-font-stretch = Default font stretch
+default-font-weight = Default font weight
+default-bold-font-weight = Default bold font weight
 default-font-size = Default font size
 default-zoom-step = Default zoom step
 

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -11,6 +11,7 @@ dark = Dark
 light = Light
 syntax-dark = Syntax dark
 syntax-light = Syntax light
+advanced-font-settings = Advanced Font Settings
 default-font = Default font
 default-font-stretch = Default font stretch
 default-font-weight = Default font weight

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,14 @@ impl App {
     }
 
     fn set_curr_font_weights_and_stretches(&mut self) {
+        // check if config font_name is available first, if not, set it to first name in list
+        if !self.font_names.contains(&self.config.font_name) {
+            log::error!("'{}' is not in the font list", self.config.font_name);
+            log::error!("setting font name to '{}'", self.font_names[0]);
+            self.config.font_name = self.font_names[0].clone();
+            let _ = self.save_config();
+        }
+
         let curr_font_faces = &self.font_name_faces_map[&self.config.font_name];
 
         self.curr_font_stretches = curr_font_faces


### PR DESCRIPTION
 * Store a font name => font faces map

 * Only list font names that have `NORMAL` and `BOLD` faces with
   `Normal` stretch. This will give us defaults and fall-backs that are
   guaranteed to always exist.

 * Filter by stretch first, with `Normal` chosen as the always existing
   default.

 * Then only list font weights supported by the font name stretch
   selected, for the normal and bold cases.

 * When changing the font name selected, the stretch/weight options
   will stay the same if supported by the new font name, or revert to
   the always existing fall-backs.