### PR TITLE
Bright bold hidden and no show cursor

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -461,6 +461,10 @@ impl Terminal {
                         )
                     };
 
+                    if indexed.cell.flags.contains(Flags::HIDDEN) {
+                        fg = bg;
+                    }
+
                     // Change color if cursor
                     if indexed.point == grid.cursor.point {
                         //TODO: better handling of cursor

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -75,6 +75,13 @@ impl EventListener for EventProxy {
     }
 }
 
+fn as_bright(mut color: Color) -> Color {
+    if let Color::Named(named) = color {
+        color = Color::Named(named.to_bright());
+    }
+    color
+}
+
 fn convert_color(colors: &Colors, color: Color) -> cosmic_text::Color {
     let rgb = match color {
         Color::Named(named_color) => match colors[named_color] {
@@ -436,14 +443,20 @@ impl Terminal {
 
                     let mut attrs = self.default_attrs;
 
+                    let cell_fg = if indexed.cell.flags.contains(Flags::BOLD) {
+                        as_bright(indexed.cell.fg)
+                    } else {
+                        indexed.cell.fg
+                    };
+
                     let (mut fg, mut bg) = if indexed.cell.flags.contains(Flags::INVERSE) {
                         (
                             convert_color(&self.colors, indexed.cell.bg),
-                            convert_color(&self.colors, indexed.cell.fg),
+                            convert_color(&self.colors, cell_fg),
                         )
                     } else {
                         (
-                            convert_color(&self.colors, indexed.cell.fg),
+                            convert_color(&self.colors, cell_fg),
                             convert_color(&self.colors, indexed.cell.bg),
                         )
                     };

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -468,7 +468,11 @@ impl Terminal {
                     // Change color if cursor
                     if indexed.point == grid.cursor.point {
                         //TODO: better handling of cursor
-                        mem::swap(&mut fg, &mut bg);
+                        if term.mode().contains(TermMode::SHOW_CURSOR) {
+                            mem::swap(&mut fg, &mut bg);
+                        } else {
+                            fg = bg;
+                        }
                     }
 
                     // Change color if selected


### PR DESCRIPTION
* Use bright color if bold.
* Support `HIDDEN` cell flag.
* Hide cursor if `TermMode::SHOW_CURSOR` is not set