### PR TITLE
Fix broken UI if font not found at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,8 +293,7 @@ impl App {
         if !self.font_names.contains(&self.config.font_name) {
             log::error!("'{}' is not in the font list", self.config.font_name);
             log::error!("setting font name to '{}'", self.font_names[0]);
-            self.config.font_name = self.font_names[0].clone();
-            let _ = self.save_config();
+            let _ = self.update(Message::DefaultFont(0));
         }
 
         let curr_font_faces = &self.font_name_faces_map[&self.config.font_name];


### PR DESCRIPTION
 Change was not reflected in settings.

 Noticed while investigating #46.