### PR TITLE
Support splitting of terminals using a Pane Grid

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -48,3 +48,6 @@ menu-settings = Settings...
 
 # Context menu
 show-headerbar = Show header bar
+split-horizontal = Split Horizontal
+split-vertical = Split Vertical
+pane-toggle-maximize = Toggle Pane Maximized

--- a/src/main.rs
+++ b/src/main.rs
@@ -589,6 +589,50 @@ impl App {
 
         widget::settings::view_column(vec![settings_view.into()]).into()
     }
+
+    fn create_and_focus_new_terminal(&mut self, pane: pane_grid::Pane) {
+        self.pane_model.focus = pane;
+        match &self.term_event_tx_opt {
+            Some(term_event_tx) => match self.themes.get(self.config.syntax_theme()) {
+                Some(colors) => {
+                    let current_pane = self.pane_model.focus;
+                    if let Some(tab_model) = self.pane_model.active_mut() {
+                        let entity = tab_model
+                            .insert()
+                            .text("New Terminal")
+                            .closable()
+                            .activate()
+                            .id();
+                        // Use the startup options, or defaults
+                        let options = self.startup_options.take().unwrap_or_default();
+                        let mut terminal = Terminal::new(
+                            current_pane,
+                            entity,
+                            term_event_tx.clone(),
+                            self.term_config.clone(),
+                            options,
+                            &self.config,
+                            *colors,
+                        );
+                        terminal.set_config(&self.config, &self.themes, self.zoom_adj);
+                        tab_model.data_set::<Mutex<Terminal>>(entity, Mutex::new(terminal));
+                    } else {
+                        log::error!("Found no active pane");
+                    }
+                }
+                None => {
+                    log::error!(
+                        "failed to find terminal theme {:?}",
+                        self.config.syntax_theme()
+                    );
+                    //TODO: fall back to known good theme
+                }
+            },
+            None => {
+                log::warn!("tried to create new tab before having event channel");
+            }
+        }
+    }
 }
 
 /// Implement [`Application`] to integrate with COSMIC.
@@ -955,49 +999,7 @@ impl Application for App {
                 );
                 if let Some((pane, _)) = result {
                     self.terminal_ids.insert(pane, widget::Id::unique());
-                    self.pane_model.focus = pane;
-
-                    match &self.term_event_tx_opt {
-                        Some(term_event_tx) => match self.themes.get(self.config.syntax_theme()) {
-                            Some(colors) => {
-                                let current_pane = self.pane_model.focus;
-                                if let Some(tab_model) = self.pane_model.active_mut() {
-                                    let entity = tab_model
-                                        .insert()
-                                        .text("New Terminal")
-                                        .closable()
-                                        .activate()
-                                        .id();
-                                    // Use the startup options, or defaults
-                                    let options = self.startup_options.take().unwrap_or_default();
-                                    let mut terminal = Terminal::new(
-                                        current_pane,
-                                        entity,
-                                        term_event_tx.clone(),
-                                        self.term_config.clone(),
-                                        options,
-                                        &self.config,
-                                        *colors,
-                                    );
-                                    terminal.set_config(&self.config, &self.themes, self.zoom_adj);
-                                    tab_model
-                                        .data_set::<Mutex<Terminal>>(entity, Mutex::new(terminal));
-                                } else {
-                                    log::error!("Found no active pane");
-                                }
-                            }
-                            None => {
-                                log::error!(
-                                    "failed to find terminal theme {:?}",
-                                    self.config.syntax_theme()
-                                );
-                                //TODO: fall back to known good theme
-                            }
-                        },
-                        None => {
-                            log::warn!("tried to create new tab before having event channel");
-                        }
-                    }
+                    self.create_and_focus_new_terminal(pane);
                     self.pane_model.panes_created += 1;
                     return self.update_title(Some(pane));
                 }
@@ -1147,46 +1149,7 @@ impl Application for App {
                     }
                 }
             }
-            Message::TabNew => match &self.term_event_tx_opt {
-                Some(term_event_tx) => match self.themes.get(self.config.syntax_theme()) {
-                    Some(colors) => {
-                        let current_pane = self.pane_model.focus;
-                        if let Some(tab_model) = self.pane_model.active_mut() {
-                            let entity = tab_model
-                                .insert()
-                                .text("New Terminal")
-                                .closable()
-                                .activate()
-                                .id();
-                            // Use the startup options, or defaults
-                            let options = self.startup_options.take().unwrap_or_default();
-                            let mut terminal = Terminal::new(
-                                current_pane,
-                                entity,
-                                term_event_tx.clone(),
-                                self.term_config.clone(),
-                                options,
-                                &self.config,
-                                *colors,
-                            );
-                            terminal.set_config(&self.config, &self.themes, self.zoom_adj);
-                            tab_model.data_set::<Mutex<Terminal>>(entity, Mutex::new(terminal));
-                        } else {
-                            log::error!("Found no active pane");
-                        }
-                    }
-                    None => {
-                        log::error!(
-                            "failed to find terminal theme {:?}",
-                            self.config.syntax_theme()
-                        );
-                        //TODO: fall back to known good theme
-                    }
-                },
-                None => {
-                    log::warn!("tried to create new tab before having event channel");
-                }
-            },
+            Message::TabNew => self.create_and_focus_new_terminal(self.pane_model.focus),
             Message::TermEvent(pane, entity, event) => {
                 match event {
                     TermEvent::Bell => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -776,6 +776,14 @@ impl Application for App {
         self.update_focus()
     }
 
+    fn on_context_drawer(&mut self) -> Command<Message> {
+        if !self.core.window.show_context {
+            self.update_focus()
+        } else {
+            Command::none()
+        }
+    }
+
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         match message {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1019,10 +1019,7 @@ impl Application for App {
                     .adjacent(self.pane_model.focus, direction)
                 {
                     self.pane_model.focus = adjacent;
-                    return Command::batch([
-                        self.update_focus(),
-                        self.update_title(Some(adjacent)),
-                    ]);
+                    return self.update_title(Some(adjacent));
                 }
             }
             Message::PaneResized(pane_grid::ResizeEvent { split, ratio }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1103,7 +1103,7 @@ impl Application for App {
                     // Remove item
                     tab_model.remove(entity);
 
-                    // If that was the last tab, close window
+                    // If that was the last tab, close current pane
                     if tab_model.iter().next().is_none() {
                         if let Some((_state, sibling)) =
                             self.pane_model.panes.close(self.pane_model.focus)
@@ -1111,6 +1111,7 @@ impl Application for App {
                             self.terminal_ids.remove(&self.pane_model.focus);
                             self.pane_model.focus = sibling;
                         } else {
+                            //Last pane, closing window
                             return window::close(window::Id::MAIN);
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1109,6 +1109,7 @@ impl Application for App {
                         if let Some((_state, sibling)) =
                             self.pane_model.panes.close(self.pane_model.focus)
                         {
+                            self.terminal_ids.remove(&self.pane_model.focus);
                             self.pane_model.focus = sibling;
                         } else {
                             return window::close(window::Id::MAIN);

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -54,6 +54,10 @@ pub fn context_menu<'a>(config: &Config, entity: segmented_button::Entity) -> El
         menu_action(fl!("paste"), Action::Paste),
         menu_action(fl!("select-all"), Action::SelectAll),
         horizontal_rule(1),
+        menu_action(fl!("split-horizontal"), Action::PaneSplitHorizontal),
+        menu_action(fl!("split-vertical"), Action::PaneSplitVertical),
+        menu_action(fl!("pane-toggle-maximize"), Action::PaneToggleMaximized),
+        horizontal_rule(1),
         menu_action(fl!("new-tab"), Action::TabNew),
         menu_action(fl!("settings"), Action::Settings),
         menu_checkbox(

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -254,7 +254,6 @@ where
             let meta = &terminal.metadata_set[terminal.default_attrs().metadata];
             let background_color = shade(meta.bg, state.is_focused);
 
-
             renderer.fill_quad(
                 Quad {
                     bounds: Rectangle::new(
@@ -307,13 +306,17 @@ where
                         }
                     }
 
-                    fn fill<Renderer: renderer::Renderer>(&mut self, renderer: &mut Renderer, is_focused: bool) {
+                    fn fill<Renderer: renderer::Renderer>(
+                        &mut self,
+                        renderer: &mut Renderer,
+                        is_focused: bool,
+                    ) {
                         if self.metadata == self.default_metadata {
                             return;
                         }
 
                         let cosmic_text_to_iced_color = |color: cosmic_text::Color| {
-                            Color::new( 
+                            Color::new(
                                 color.r() as f32 / 255.0,
                                 color.g() as f32 / 255.0,
                                 color.b() as f32 / 255.0,

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1079,19 +1079,15 @@ where
 
 fn shade(color: cosmic_text::Color, is_focused: bool) -> cosmic_text::Color {
     if is_focused {
-        log::debug!("No shade {:?}", color.as_rgba());
         color
     } else {
-        log::debug!("Shade orig {:?}", color.as_rgba());
         let shade = 0.92;
-        let new = cosmic_text::Color::rgba(
+        cosmic_text::Color::rgba(
             (color.r() as f32 * shade) as u8,
             (color.g() as f32 * shade) as u8,
             (color.b() as f32 * shade) as u8,
             color.a(),
-        );
-        log::debug!("Shade new {:?}", new.as_rgba());
-        new
+        )
     }
 }
 

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -255,6 +255,7 @@ where
             let background_color = meta.bg;
 
             //TODO: get shaded background color from theme
+            /*
             let mut shade: f32 = 1.0;
             if !state.is_focused {
                 shade = 0.90;
@@ -264,6 +265,13 @@ where
                 background_color.g() as f32 * shade / 255.0,
                 background_color.b() as f32 * shade / 255.0,
                 background_color.a() as f32 * shade / 255.0,
+            );
+            */
+            let background = Color::new(
+                background_color.r() as f32 / 255.0,
+                background_color.g() as f32 / 255.0,
+                background_color.b() as f32 / 255.0,
+                background_color.a() as f32 / 255.0,
             );
 
             renderer.fill_quad(


### PR DESCRIPTION
I have implemented split terminals adding a pane grid. 
The keys are the same as Tilix
Ctrl-Alt-R  for split vertical
Ctrl-Alt-D for split horizontal
Ctrl-Shift-X for toggle maximised. 
Ctrl-Shift-<arrow> to navigate between panes

Outstanding things to be clarified and fixed:
1. In terminal_box.rs I have blocked crtl-alt control keys from being sent, since ctrl-alt-d would cause an exit if not. Not sure if this is safe, or if it only should prevent this for the specific key bindings. 
2. I have added a shade to the background, by just making it slightly darker for non focused panes. This should probably come from the theme, where a non-focused background could be specified or something like that. How this should be handled properly must be decided by some that knows more about the cosmic desktop.