### PR TITLE
Fix tab skip rendering

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -633,7 +633,8 @@ impl Terminal {
                             buffer.set_redraw(true);
                         }
 
-                        if buffer.lines[line_i].set_text(text.clone(), attrs_list.clone()) {
+                        // Tab skip/stop is handled by alacritty_terminal
+                        if buffer.lines[line_i].set_text(text.replace('\t', " "), attrs_list.clone()) {
                             buffer.set_redraw(true);
                         }
                         line_i += 1;


### PR DESCRIPTION
 Replace '\t' with a space in text buffers, as tab skip/stop is handled
 by `alacritty_terminal`.

 Also, sending a tab to the shaper causes issues, as fonts either have
 no tab codepoint, or worse, some do, with the glyph produced being
 anyone's guess. Some may render a tab to some random character like
 '0'.

 Fixes #73.