### PR TITLE
Focus Follows Mouse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ palette = "0.7"
 git = "https://github.com/pop-os/cosmic-text.git"
 
 [dependencies.libcosmic]
-git = "https://github.com/pop-os/libcosmic.git"
+#git = "https://github.com/pop-os/libcosmic.git"
 default-features = false
 features = ["tokio", "winit"]
-#path = "../libcosmic"
+path = "../libcosmic"
 
 [features]
 default = ["wgpu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ palette = "0.7"
 git = "https://github.com/pop-os/cosmic-text.git"
 
 [dependencies.libcosmic]
-#git = "https://github.com/pop-os/libcosmic.git"
+git = "https://github.com/pop-os/libcosmic.git"
 default-features = false
 features = ["tokio", "winit"]
-path = "../libcosmic"
+#path = "../libcosmic"
 
 [features]
 default = ["wgpu"]

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -2,6 +2,7 @@
 
 ## Settings
 settings = Settings
+focus-follow-mouse = Focus Follow Mouse
 
 ### Appearance
 appearance = Appearance

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,7 @@ pub struct Config {
     pub use_bright_bold: bool,
     pub syntax_theme_dark: String,
     pub syntax_theme_light: String,
+    pub focus_follow_mouse: bool,
 }
 
 impl Default for Config {
@@ -60,6 +61,7 @@ impl Default for Config {
             use_bright_bold: false,
             syntax_theme_dark: "COSMIC Dark".to_string(),
             syntax_theme_light: "COSMIC Light".to_string(),
+            focus_follow_mouse: false,
         }
     }
 }


### PR DESCRIPTION
I have added an option to let the focus follow the mouse pointer, without having to click. It is a sloppy focus, so it only changes focus on mouse pointer enter. 

Two things: 
1. I know that Focus Follows Mouse sounds like a window manager level thing, but since we have panes, we need to support it on the application level, since focus between panes also follows the mouse. 
2. I also realize that this may fall under weird workflows (ref: https://xkcd.com/1172/ ), but I hope you find it useful enough to include anyway  :)  I was kind enought to hide it behind a setting that defaults to off. 
