### PR TITLE
Disable window content container and set style on pane grid container

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -717,8 +717,7 @@ impl Application for App {
 
     /// Creates the application, and optionally emits command on initialize.
     fn init(mut core: Core, flags: Self::Flags) -> (Self, Command<Self::Message>) {
-        //TODO: fix window resizing interfering with scrolling when not using content container
-        //core.window.content_container = false;
+        core.window.content_container = false;
         core.window.show_headerbar = flags.config.show_headerbar;
 
         // Update font name from config
@@ -1520,6 +1519,7 @@ impl Application for App {
             .width(Length::Fill)
             .height(Length::Fill)
             .padding(space_xxs)
+            .style(style::Container::Background)
             .into()
     }
 


### PR DESCRIPTION
 * Presumably, the TODO about window resizing interfering with scrolling is not applicable anymore with the existence of padding from the pane grid container. So, set `core.window.content_container` to false.

 * Pane grid container didn't follow the selected theme. So, set style on it to fix that.