### PR TITLE
RFC: Maximize horizontal use of terminal view

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -717,8 +717,7 @@ impl Application for App {
 
     /// Creates the application, and optionally emits command on initialize.
     fn init(mut core: Core, flags: Self::Flags) -> (Self, Command<Self::Message>) {
-        //TODO: fix window resizing interfering with scrolling when not using content container
-        //core.window.content_container = false;
+        core.window.content_container = false;
         core.window.show_headerbar = flags.config.show_headerbar;
 
         // Update font name from config
@@ -1520,6 +1519,7 @@ impl Application for App {
             .width(Length::Fill)
             .height(Length::Fill)
             .padding(space_xxs)
+            .style(style::Container::Background)
             .into()
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -175,6 +175,8 @@ impl Metadata {
 }
 
 pub struct Terminal {
+    pub pane: pane_grid::Pane,
+    pub entity: segmented_button::Entity,
     default_attrs: Attrs<'static>,
     buffer: Arc<Buffer>,
     size: Size,
@@ -261,6 +263,8 @@ impl Terminal {
         let _pty_join_handle = pty_event_loop.spawn();
 
         Self {
+            pane,
+            entity,
             colors,
             dim_font_weight: Weight(dim_font_weight),
             bold_font_weight: Weight(bold_font_weight),


### PR DESCRIPTION
A couple of proposed changes on top of #79. This is scratching an itch I always had with `cosmic-term`. But others may consider the changes proposed here overkill.

## Scrollback Changes

 * Don't clamp cols to before the scrollbar rectangle.
 * Auto-hide the scrollbar if a pane is not focused, or if there is no mouse activity.

## Text changes

Slightly increase font size to get rid of the spare pixels that don't fit into a column at the end of a line.

## Screenshots

These are taken with OneHalfDark on Light for clarity.

### Current

![master](https://github.com/pop-os/cosmic-term/assets/5631214/3cb84ac2-2de2-482f-ae00-42dc3a4fa57f)

### With #79 

![no_wc](https://github.com/pop-os/cosmic-term/assets/5631214/c372483a-478d-465d-a14b-e7894b17f1ca)


### With scrollback changes

![no_scroll_reserve](https://github.com/pop-os/cosmic-term/assets/5631214/9d6a0982-356c-4db0-b0ae-5454828d4442)

### With font size increase

This fixes an issue that also exists in `alacritty`. But I never saw it in the previous terminals I used.

![max_hor](https://github.com/pop-os/cosmic-term/assets/5631214/16d69983-0821-4275-8bc9-0a49d918af04)
