### PR TITLE
Ensure terminal is focused after paste

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1138,6 +1138,7 @@ impl Application for App {
                         terminal.paste(value);
                     }
                 }
+                return self.update_focus();
             }
             Message::SelectAll(entity_opt) => {
                 if let Some(tab_model) = self.pane_model.active() {


### PR DESCRIPTION
When you paste using context meny, the focus is lost. This just ensures that we give back focus to the terminal after paste. 

Fixes the issue mentioned here
https://github.com/pop-os/cosmic-term/issues/107#issuecomment-1925905062