### PR TITLE
Bump alacritty_terminal to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,11 +126,11 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121a8d385a114873632d785a99614ae1d324b3e38b9da8a92138c8799b50fdc"
+checksum = "f6d1ea4484c8676f295307a4892d478c70ac8da1dbd8c7c10830a504b7f1022f"
 dependencies = [
- "base64",
+ "base64 0.22.0",
  "bitflags 2.4.2",
  "home",
  "libc",
@@ -630,6 +630,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bit-set"
@@ -4235,7 +4241,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "serde",
  "serde_derive",
@@ -5213,7 +5219,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b0a51b72ab80ca511d126b77feeeb4fb1e972764653e61feac30adc161a756"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "log",
  "pico-args",
  "usvg-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.71"
 vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dependencies]
-alacritty_terminal = "0.20"
+alacritty_terminal = "0.23"
 env_logger = "0.10"
 hex_color = { version = "3", features = ["serde"] }
 indexmap = "2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1165,6 +1165,7 @@ impl App {
                                         working_directory: None,
                                         //TODO: configurable hold (keep open when child exits)?
                                         hold: false,
+                                        env: HashMap::new(),
                                     };
                                     let tab_title_override = if !profile.tab_title.is_empty() {
                                         Some(profile.tab_title.clone())
@@ -2235,6 +2236,9 @@ impl Application for App {
                             }
                         }
                     }
+                    TermEvent::ChildExit(_error_code) => {
+                        //Ignore this for now
+                    },
                 }
             }
             Message::TermEventTx(term_event_tx) => {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -276,7 +276,7 @@ impl Terminal {
         let window_id = 0;
         let pty = tty::new(&options, size.into(), window_id)?;
 
-        let pty_event_loop = EventLoop::new(term.clone(), event_proxy, pty, options.hold, false);
+        let pty_event_loop = EventLoop::new(term.clone(), event_proxy, pty, options.hold, false)?;
         let notifier = Notifier(pty_event_loop.channel());
         let _pty_join_handle = pty_event_loop.spawn();
 
@@ -876,6 +876,8 @@ impl Terminal {
 impl Drop for Terminal {
     fn drop(&mut self) {
         // Ensure shutdown on terminal drop
-        self.notifier.0.send(Msg::Shutdown);
+        if let Err(err) = self.notifier.0.send(Msg::Shutdown) {
+            log::warn!("Failed to send shutdown message on dropped terminal: {err}");
+        }
     }
 }


### PR DESCRIPTION
This just bumps alacritty_terminal to 0.23. 

Not sure if we want to handle the new TermEvent::ChildExit(_error_code ) event in any special way? I just ignore it for now. 
Also  the call `self.notifier.0.send(Msg::Shutdown) ` now returns a Result, so I just added an error message if this fails (since it is in a drop call, it is not possible to recover in a good way I guess). 
The other thing seems to be that it is now possible to send in extra environment variable when you create the terminal, which I just left empty.