### PR TITLE
Rename gruvbox color scheme to match all the others

### DIFF
--- a/color-schemes/Gruvbox Dark.ron
+++ b/color-schemes/Gruvbox Dark.ron
@@ -1,5 +1,5 @@
 (
-    name: "gruvbox-dark",
+    name: "Gruvbox Dark",
     foreground: "#EBDBB2",
     background: "#282828",
     cursor: "#EBDBB2",


### PR DESCRIPTION
It have always bothered me that the gruvbox color scheme didn't have the same naming convention that the other color schemes. This is just a simple rename to fix that. 