### PR TITLE
Add fallback if selected color theme is not present

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ use std::sync::OnceLock;
 use crate::fl;
 
 pub const CONFIG_VERSION: u64 = 1;
+pub const COSMIC_THEME_DARK: &str = "COSMIC Dark";
+pub const COSMIC_THEME_LIGHT: &str = "COSMIC Light";
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum AppTheme {
@@ -193,8 +195,8 @@ impl Default for Profile {
         Self {
             name: fl!("new-profile"),
             command: String::new(),
-            syntax_theme_dark: "COSMIC Dark".to_string(),
-            syntax_theme_light: "COSMIC Light".to_string(),
+            syntax_theme_dark: COSMIC_THEME_DARK.to_string(),
+            syntax_theme_light: COSMIC_THEME_LIGHT.to_string(),
             tab_title: String::new(),
         }
     }
@@ -239,8 +241,8 @@ impl Default for Config {
             opacity: 100,
             profiles: BTreeMap::new(),
             show_headerbar: true,
-            syntax_theme_dark: "COSMIC Dark".to_string(),
-            syntax_theme_light: "COSMIC Light".to_string(),
+            syntax_theme_dark: COSMIC_THEME_DARK.to_string(),
+            syntax_theme_light: COSMIC_THEME_LIGHT.to_string(),
             use_bright_bold: false,
             default_profile: None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1135,7 +1135,15 @@ impl App {
         self.pane_model.focus = pane;
         match &self.term_event_tx_opt {
             Some(term_event_tx) => {
-                match self.themes.get(&self.config.syntax_theme(profile_id_opt)) {
+                let colors = self
+                    .themes
+                    .get(&self.config.syntax_theme(profile_id_opt))
+                    .or_else(|| {
+                        let mut keys: Vec<_> = self.themes.keys().collect();
+                        keys.sort_by(|a, b| (&a.0).cmp(&b.0));
+                        keys.first().and_then(|key| self.themes.get(key))
+                    });
+                match colors {
                     Some(colors) => {
                         let current_pane = self.pane_model.focus;
                         if let Some(tab_model) = self.pane_model.active_mut() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1138,10 +1138,14 @@ impl App {
                 let colors = self
                     .themes
                     .get(&self.config.syntax_theme(profile_id_opt))
-                    .or_else(|| {
-                        let mut keys: Vec<_> = self.themes.keys().collect();
-                        keys.sort_by(|a, b| (&a.0).cmp(&b.0));
-                        keys.first().and_then(|key| self.themes.get(key))
+                    .or_else(|| match self.config.color_scheme_kind() {
+                        ColorSchemeKind::Dark => self
+                            .themes
+                            .get(&(config::COSMIC_THEME_DARK.to_string(), ColorSchemeKind::Dark)),
+                        ColorSchemeKind::Light => self.themes.get(&(
+                            config::COSMIC_THEME_LIGHT.to_string(),
+                            ColorSchemeKind::Light,
+                        )),
                     });
                 match colors {
                     Some(colors) => {

--- a/src/terminal_theme.rs
+++ b/src/terminal_theme.rs
@@ -6,7 +6,9 @@ use hex_color::HexColor;
 use palette::{encoding::Srgb, rgb::Rgb as PRgb, FromColor, Okhsl};
 use std::{collections::HashMap, fs};
 
-use crate::config::{ColorScheme, ColorSchemeAnsi, ColorSchemeKind};
+use crate::config::{
+    ColorScheme, ColorSchemeAnsi, ColorSchemeKind, COSMIC_THEME_DARK, COSMIC_THEME_LIGHT,
+};
 
 // Fill missing dim/bright colors with derived values from normal ones.
 #[allow(dead_code)]
@@ -338,11 +340,11 @@ fn cosmic_light() -> Colors {
 pub fn terminal_themes() -> HashMap<(String, ColorSchemeKind), Colors> {
     let mut themes = HashMap::new();
     themes.insert(
-        ("COSMIC Dark".to_string(), ColorSchemeKind::Dark),
+        (COSMIC_THEME_DARK.to_string(), ColorSchemeKind::Dark),
         cosmic_dark(),
     );
     themes.insert(
-        ("COSMIC Light".to_string(), ColorSchemeKind::Light),
+        (COSMIC_THEME_LIGHT.to_string(), ColorSchemeKind::Light),
         cosmic_light(),
     );
     themes


### PR DESCRIPTION
The fallback is the first available theme when sorted, this is to make things predictable and to get the same theme if you open the terminal multiple times

I added this since the color theme handling changed, and I ended up with only a titlebar... thought this would be better.