### PR TITLE
Add tty working dir and hold

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -23,6 +23,9 @@ tab-title-description = Override the default tab title
 add-profile = Add profile
 new-profile = New profile
 make-default = Make default
+working-directory = Working directory
+hold = Hold
+remain-open = Remain open after child process exits.
 
 ## Settings
 settings = Settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,10 @@ pub struct Profile {
     pub syntax_theme_light: String,
     #[serde(default)]
     pub tab_title: String,
+    #[serde(default)]
+    pub working_directory: String,
+    #[serde(default)]
+    pub hold: bool,
 }
 
 impl Default for Profile {
@@ -196,6 +200,8 @@ impl Default for Profile {
             syntax_theme_dark: "COSMIC Dark".to_string(),
             syntax_theme_light: "COSMIC Light".to_string(),
             tab_title: String::new(),
+            working_directory: String::new(),
+            hold: true,
         }
     }
 }


### PR DESCRIPTION
See #179 for more reasons why these options are useful.
For the working directory, if the shell does not provide to execute a command at startup, you will need to something like `bash -c "cd somewhere; exex bash"`.
For hold, I think true should be the default , since like in the issue above, the terminal will exit if it also a  default, which means you will have to edit or remove the config file manually and have no GUI. 
Hold probably should be a drop down like in gnome terminal, for now just a showcase. 