### PR TITLE
pkg_config in nix flake: allow to build on pop_os with nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /vendor/
 /.direnv/
 /.idea/
+nohup.out

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,10 @@
               xorg.libX11
             ];
 
+            nativeBuildInputs = [
+              pkg-config
+            ];
+
             RUSTFLAGS = map (a: "-C link-arg=${a}") [
               "-Wl,--push-state,--no-as-needed"
               "-lEGL"


### PR DESCRIPTION
See https://discourse.nixos.org/t/how-to-add-pkg-config-file-to-a-nix-package/8264

The error I got was:

```
error: failed to run custom build command for `smithay-client-toolkit v0.18.0 (https://github.com/smithay/client-toolkit?rev=3bed072#3bed072b)`

Caused by:
  process didn't exit successfully: `/home/bbarker/workspace/cosmic-term/target/debug/build/smithay-client-toolkit-8d8160159951de77/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=XKBCOMMON_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=XKBCOMMON_STATIC
  cargo:rerun-if-env-changed=XKBCOMMON_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  thread 'main' panicked at /home/bbarker/.cargo/git/checkouts/client-toolkit-e56a3844de110279/3bed072/build.rs:3:49:
  called `Result::unwrap()` on an `Err` value: "\npkg-config exited with status code 1\n> PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags xkbcommon\n\nThe system library `xkbcommon` required by crate `smithay-client-toolkit` was not found.\nThe file `xkbcommon.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.\nThe PKG_CONFIG_PATH environment variable is not set.\n\nHINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `xkbcommon.pc`.\n"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```