### PR TITLE
fix: Use X-COSMIC as a category, not COSMIC

### DIFF
--- a/res/com.system76.CosmicTerm.desktop
+++ b/res/com.system76.CosmicTerm.desktop
@@ -7,6 +7,6 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Icon=com.system76.CosmicTerm
-Categories=COSMIC;System;TerminalEmulator;
+Categories=X-COSMIC;System;TerminalEmulator;
 Keywords=Command;Shell;Terminal;
 Keywords[pl]=Cli;WierszPoleceń;Powłoka;Terminal;


### PR DESCRIPTION
This makes the desktop file "valid". When we run `desktop-file-validate`, we currently get:

```
cosmic-term.x86_64: E: invalid-desktopfile /usr/share/applications/com.system76.CosmicTerm.desktop value "COSMIC;System;TerminalEmulator;" for key "Categories" in group "Desktop Entry" contains an unregistered value "COSMIC"; values extending the format should start with "X-"
```

I'll be making PRs for the other COSMIC desktop files, too :)