### PR TITLE
Cursor color from request or color theme

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -746,6 +746,10 @@ impl Terminal {
                             if term.colors()[NamedColor::Cursor].is_some() {
                                 fg = bg;
                                 bg = convert_color(term.colors(), Color::Named(NamedColor::Cursor));
+                            } else if self.colors[NamedColor::Cursor].is_some() {
+                                //Use specific theme cursor color if exists
+                                fg = bg;
+                                bg = convert_color(&self.colors, Color::Named(NamedColor::Cursor));
                             } else {
                                 mem::swap(&mut fg, &mut bg);
                             }


### PR DESCRIPTION
If a specific cursor color is requested (by printf "\x1b]12;#8000ff\x1b\\" ), then this is set in the alacritty terminal colors, so this patch simply check that and uses that when set. I also added a check for cursor contrast. 
I also added so the cursor color from the color theme is used if it exists.