### PR TITLE
feat: Profile option to open new terms in last focused term's CWD [rebased 2025-07-26]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "paste",
  "ron 0.8.1",
  "rust-embed",
+ "rustix 0.38.44",
  "serde",
  "shlex",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ dependencies = [
  "paste",
  "ron 0.8.1",
  "rust-embed",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "serde",
  "shlex",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
-rustix = { version = "0.38", features = ["termios"] }
+rustix = { version = "1", features = ["process", "termios"] }
 # CLI arguments
 clap_lex = "0.7"
 # Internationalization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
+rustix = { version = "0.38", features = ["termios"] }
 # CLI arguments
 clap_lex = "0.7"
 # Internationalization

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -60,6 +60,8 @@ focus-follow-mouse = Typing focus follows mouse
 advanced = Advanced
 show-headerbar = Show header
 show-header-description = Reveal the header from the right-click menu.
+open-in-cwd = Use parent CWD
+open-in-cwd-description = Start new terms using the focused tab's working directory.
 
 # Find
 find-placeholder = Find...

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -26,6 +26,8 @@ make-default = Make default
 working-directory = Working directory
 hold = Hold
 remain-open = Remain open after child process exits.
+open-in-cwd = Use parent CWD
+open-in-cwd-description = Open new terminals using the focused tab's working directory.
 
 ## Settings
 settings = Settings
@@ -60,8 +62,6 @@ focus-follow-mouse = Typing focus follows mouse
 advanced = Advanced
 show-headerbar = Show header
 show-header-description = Reveal the header from the right-click menu.
-open-in-cwd = Use parent CWD
-open-in-cwd-description = Start new terms using the focused tab's working directory.
 
 # Find
 find-placeholder = Find...

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,9 @@ pub struct Profile {
     pub tab_title: String,
     #[serde(default)]
     pub working_directory: String,
+    /// Open new terminal with the current working directory of the focused term
+    #[serde(default = "cwd_default")]
+    pub open_in_cwd: bool,
     #[serde(default)]
     pub hold: bool,
 }
@@ -212,8 +215,18 @@ impl Default for Profile {
             tab_title: String::new(),
             working_directory: String::new(),
             hold: false,
+            open_in_cwd: cwd_default(),
         }
     }
+}
+
+#[cfg(not(windows))]
+const fn cwd_default() -> bool {
+    true
+}
+#[cfg(windows)]
+const fn cwd_default() -> bool {
+    false
 }
 
 #[derive(Clone, CosmicConfigEntry, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -229,8 +242,6 @@ pub struct Config {
     pub font_stretch: u16,
     pub font_size_zoom_step_mul_100: u16,
     pub opacity: u8,
-    /// Open new terminal with the current working directory of the focused term
-    pub open_in_cwd: bool,
     pub profiles: BTreeMap<ProfileId, Profile>,
     pub show_headerbar: bool,
     pub use_bright_bold: bool,
@@ -255,7 +266,6 @@ impl Default for Config {
             font_stretch: Stretch::Normal.to_number(),
             font_weight: Weight::NORMAL.0,
             opacity: 100,
-            open_in_cwd: true,
             profiles: BTreeMap::new(),
             show_headerbar: true,
             syntax_theme_dark: COSMIC_THEME_DARK.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,8 @@ pub struct Config {
     pub font_stretch: u16,
     pub font_size_zoom_step_mul_100: u16,
     pub opacity: u8,
+    /// Open new terminal with the current working directory of the focused term
+    pub open_in_cwd: bool,
     pub profiles: BTreeMap<ProfileId, Profile>,
     pub show_headerbar: bool,
     pub use_bright_bold: bool,
@@ -253,6 +255,7 @@ impl Default for Config {
             font_stretch: Stretch::Normal.to_number(),
             font_weight: Weight::NORMAL.0,
             opacity: 100,
+            open_in_cwd: true,
             profiles: BTreeMap::new(),
             show_headerbar: true,
             syntax_theme_dark: COSMIC_THEME_DARK.to_string(),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -24,6 +24,8 @@ use cosmic_text::{
     Weight, Wrap,
 };
 use indexmap::IndexSet;
+#[cfg(not(windows))]
+use rustix::fd::AsFd;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -34,6 +36,8 @@ use std::{
     },
     time::Instant,
 };
+#[cfg(not(windows))]
+use std::{fs, path::PathBuf};
 use tokio::sync::mpsc;
 
 pub use alacritty_terminal::grid::Scroll as TerminalScroll;
@@ -257,6 +261,10 @@ pub struct Terminal {
     size: Size,
     use_bright_bold: bool,
     zoom_adj: i8,
+    #[cfg(not(windows))]
+    master_fd: Option<rustix::fd::OwnedFd>,
+    #[cfg(not(windows))]
+    shell_pid: rustix::process::Pid,
 }
 
 impl Terminal {
@@ -326,6 +334,11 @@ impl Terminal {
         let window_id = 0;
         let pty = tty::new(&options, size.into(), window_id)?;
 
+        #[cfg(not(windows))]
+        let master_fd = pty.file().as_fd().try_clone_to_owned().ok();
+        #[cfg(not(windows))]
+        let shell_pid = rustix::process::Pid::from_child(pty.child());
+
         let pty_event_loop = EventLoop::new(term.clone(), event_proxy, pty, options.hold, false)?;
         let notifier = Notifier(pty_event_loop.channel());
         let _pty_join_handle = pty_event_loop.spawn();
@@ -353,6 +366,10 @@ impl Terminal {
             use_bright_bold,
             zoom_adj: Default::default(),
             is_focused: true,
+            #[cfg(not(windows))]
+            master_fd,
+            #[cfg(not(windows))]
+            shell_pid,
         })
     }
 
@@ -1002,6 +1019,32 @@ impl Terminal {
                 delta,
             );
         }
+    }
+
+    /// Current working directory
+    #[cfg(not(windows))]
+    pub fn current_working_directory(&self) -> Option<PathBuf> {
+        // Largely based off of Alacritty
+        // https://github.com/alacritty/alacritty/blob/6bd1674bd80e73df0d41e4342ad4e34bb7d04f84/alacritty/src/daemon.rs#L85-L108
+        let pid = self
+            .master_fd
+            .as_ref()
+            .and_then(|pid| rustix::termios::tcgetpgrp(pid).ok())
+            .or(Some(self.shell_pid))?;
+
+        #[cfg(not(any(target_os = "freebsd", target_os = "macos")))]
+        let link_path = format!("/proc/{}/cwd", pid.as_raw_nonzero());
+        #[cfg(target_os = "freebsd")]
+        let link_path = format!("/compat/linux/proc/{}/cwd", pid.as_raw_nonzero());
+
+        #[cfg(not(target_os = "macos"))]
+        let cwd = fs::read_link(link_path).ok();
+
+        // TODO: macOS support
+        #[cfg(target_os = "macos")]
+        let cwd = None;
+
+        cwd
     }
 }
 /// Iterate over all visible regex matches.


### PR DESCRIPTION
Closes: #251

This patch implements an optional (but enabled by default) feature for opening new terminals using the focused terminal's working directory. The code to retrieve the CWD is largely based on Alacritty's implementation of the same feature.

It works but I have one small change to work on later.

Todo:
- [x] Add a config option to revert to the old behavior