### PR TITLE
Support drag-and-drop for files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
  "shlex",
  "smol_str",
  "tokio",
+ "url",
  "vergen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ i18n-embed-fl = "0.7"
 icu_collator = "1.5"
 icu_provider = { version = "1.5", features = ["sync"] }
 rust-embed = "8"
+url = "2.5"
 
 [dependencies.cosmic-files]
 git = "https://github.com/pop-os/cosmic-files.git"

--- a/src/dnd.rs
+++ b/src/dnd.rs
@@ -1,0 +1,51 @@
+use cosmic::iced::clipboard::mime::AllowedMimeTypes;
+use std::{borrow::Cow, error::Error, path::PathBuf, str};
+use url::Url;
+
+#[derive(Clone, Debug)]
+pub struct DndDrop {
+    pub paths: Vec<PathBuf>,
+}
+
+impl AllowedMimeTypes for DndDrop {
+    fn allowed() -> Cow<'static, [String]> {
+        Cow::from(vec![
+            "x-special/gnome-copied-files".to_string(),
+            "text/uri-list".to_string(),
+        ])
+    }
+}
+
+impl TryFrom<(Vec<u8>, String)> for DndDrop {
+    type Error = Box<dyn Error>;
+    fn try_from(value: (Vec<u8>, String)) -> Result<Self, Self::Error> {
+        let (data, mime) = value;
+        let mut paths = Vec::new();
+        match mime.as_str() {
+            "text/uri-list" => {
+                let text = str::from_utf8(&data)?;
+                for line in text.lines() {
+                    let url = Url::parse(line)?;
+                    match url.to_file_path() {
+                        Ok(path) => paths.push(path),
+                        Err(()) => Err(format!("invalid file URL {:?}", url))?,
+                    }
+                }
+            }
+            "x-special/gnome-copied-files" => {
+                let text = str::from_utf8(&data)?;
+                for (i, line) in text.lines().enumerate() {
+                    if i != 0 {
+                        let url = Url::parse(line)?;
+                        match url.to_file_path() {
+                            Ok(path) => paths.push(path),
+                            Err(()) => Err(format!("invalid file URL {:?}", url))?,
+                        }
+                    }
+                }
+            }
+            _ => Err(format!("unsupported mime type {:?}", mime))?,
+        }
+        Ok(Self { paths })
+    }
+}


### PR DESCRIPTION
Insert file paths when files are dropped in terminal from a file manager.

Closes #86

This requires changes to iced to support drag-and-drop into a pane grid. I opened a PR for that here.
https://github.com/pop-os/iced/pull/166