### PR TITLE
Zoom per tab/pane & skip writing config to fs when zooming -  considerable perf improvement when zooming

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -139,6 +139,7 @@ fn convert_color(colors: &Colors, color: Color) -> cosmic_text::Color {
 }
 
 type TabModel = segmented_button::Model<segmented_button::SingleSelect>;
+
 pub struct TerminalPaneGrid {
     pub panes: pane_grid::State<TabModel>,
     pub panes_created: usize,
@@ -212,6 +213,7 @@ pub struct Terminal {
     search_value: String,
     size: Size,
     use_bright_bold: bool,
+    zoom_adj: i8
 }
 
 impl Terminal {
@@ -303,6 +305,7 @@ impl Terminal {
             tab_title_override,
             term,
             use_bright_bold,
+            zoom_adj: Default::default()
         })
     }
 
@@ -330,6 +333,14 @@ impl Terminal {
 
     pub fn size(&self) -> Size {
         self.size
+    }
+
+    pub fn zoom_adj(&self) -> i8 {
+        self.zoom_adj
+    }
+
+    pub fn set_zoom_adj(&mut self, value: i8) {
+        self.zoom_adj = value;
     }
 
     pub fn redraw(&self) -> bool {
@@ -528,11 +539,10 @@ impl Terminal {
         &mut self,
         config: &AppConfig,
         themes: &HashMap<(String, ColorSchemeKind), Colors>,
-        zoom_adj: i8,
     ) {
         let mut update_cell_size = false;
         let mut update = false;
-
+        let zoom_adj = self.zoom_adj;
         if self.default_attrs.stretch != config.typed_font_stretch() {
             self.default_attrs = self.default_attrs.stretch(config.typed_font_stretch());
             update_cell_size = true;


### PR DESCRIPTION
### Issues: #301 and the perf related:  #227
### Before:

1.  Zooming is applied to all panes at the same time
2. Considerate amount of lag due to  the known issue when updating the config in the filesystem ( using an old SATA  Samsung SSD 840: https://www.samsung.com/us/business/support/owners/product/840-evo-series-250gb/ , maybe with an NVME with 5x write speed it is not noticable for others.)

You can observe the lag in the video: 


https://github.com/user-attachments/assets/4895faba-61c7-47f1-ae1c-2f786d3b67c0

### After

1. Zooming is applied in the active pane(entity).
2. It is really snappy.


https://github.com/user-attachments/assets/3df89562-0af8-4d94-9f75-02ae78337bb5

#### Note: I am still resetting all the panes when changing the default font size from settings adhering to the current behaviour.


https://github.com/user-attachments/assets/531441fb-caa6-4f61-9eed-29c1d56b6032
