### PR TITLE
Change the default "hold" value when creating new profile as it creates…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -211,7 +211,7 @@ impl Default for Profile {
             syntax_theme_light: COSMIC_THEME_LIGHT.to_string(),
             tab_title: String::new(),
             working_directory: String::new(),
-            hold: true,
+            hold: false,
         }
     }
 }


### PR DESCRIPTION
… issues. #284  , 
#191 
People are complaining that they cannot exit their terminal. I consider it a bad user experience but this is my personal opinion of course. Also, this matches with the current behaviour when **no** profile is applied. This feature should be "opt-in".

This  flag is  currently set to true by default when creating a new profile as seen in the screenshot: 
![screenshot-2024-08-25-19-57-01](https://github.com/user-attachments/assets/071bb251-10f4-4377-b869-ed179174e3e0)
