### PR TITLE
Fix regression with hidden cursors

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -758,7 +758,7 @@ impl Terminal {
 
                     // Change color if cursor
                     if indexed.point == grid.cursor.point
-                        && term.cursor_style().shape == CursorShape::Block
+                        && term.renderable_content().cursor.shape == CursorShape::Block
                     {
                         //Use specific cursor color if requested
                         if term.colors()[NamedColor::Cursor].is_some() {


### PR DESCRIPTION
Fix regression caused by #306 (my bad ;P) where hiding cursor didn't work correctly.

Can be tested with `echo -e "\e[?25l"` which should hide the cursor.
