### PR TITLE
Remove unused patch for libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7299,8 +7299,3 @@ dependencies = [
  "quote",
  "syn 2.0.76",
 ]
-
-[[patch.unused]]
-name = "libc"
-version = "0.2.154"
-source = "git+https://gitlab.redox-os.org/redox-os/liblibc.git?branch=redox-epoll-0.2#5eff703b923d3e1b042e91bc67409cca961f3976"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,6 @@ debug = true
 [patch.crates-io]
 # https://github.com/alexcrichton/filetime/pull/104
 filetime = { git = "https://github.com/jackpot51/filetime" }
-# https://github.com/rust-lang/libc/pull/3686
-libc = { git = "https://gitlab.redox-os.org/redox-os/liblibc.git", branch = "redox-epoll-0.2" }
 
 # [patch.'https://github.com/pop-os/libcosmic']
 # libcosmic = { git = "https://github.com/pop-os/libcosmic//", branch = "zbus-4" }


### PR DESCRIPTION
See <https://github.com/pop-os/cosmic-term/commit/193746ffbc90c8bcb7a7ff226422d56e4e404d98#r145969203> (cc @jackpot51)

This patch became unused in 193746ffbc90c8bcb7a7ff226422d56e4e404d98, when upstream libc was bumped past the version that included the commit from the referenced PR