### PR TITLE
Fix <C-Space> Handling to Send Correct Control Character (\x00)

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -778,7 +778,12 @@ where
                         status = Status::Captured;
                     }
                     Named::Space => {
-                        terminal.input_scroll(format!("{}{}", alt_prefix, " ").into_bytes());
+                        if modifiers.control() {
+                            // Send NUL character (\x00) for Ctrl + Space
+                            terminal.input_scroll(b"\x00".to_vec());
+                        } else {
+                            terminal.input_scroll(format!("{}{}", alt_prefix, " ").into_bytes());
+                        }                        
                         status = Status::Captured;
                     }
                     Named::Tab => {


### PR DESCRIPTION
### Summary
This PR addresses [issue #327](https://github.com/pop-os/cosmic-term/issues/327), where pressing <C-Space> (Control + Space) in cosmic-term does not send the correct control character to terminal applications. Instead of sending a NUL character (\x00), it was sending a regular space character, causing issues in applications like Neovim that rely on <C-Space> for certain functionalities (e.g., triggering autocompletion with nvim-cmp).
