### PR TITLE
i18n/fi: remove extra 'i' from "Profiiilit"

### DIFF
--- a/i18n/fi/cosmic_term.ftl
+++ b/i18n/fi/cosmic_term.ftl
@@ -18,7 +18,7 @@ import-errors = Tuo virheet
 
 ## Profiles
 
-profiles = Profiiilit
+profiles = Profiilit
 name = Nimi
 command-line = Komentorivi
 tab-title = Välilehden otsikko


### PR DESCRIPTION
- There was a typo (an extra 'i') in the Profiles menu title.
- This has now been fixed.