### PR TITLE
Round window corners based on header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "apply"
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1172,7 +1172,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1280,7 +1280,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "futures",
  "iced_core",
@@ -2680,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2714,7 +2714,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "bytes",
  "dnd",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.6.0",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2794,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3327,7 +3327,7 @@ checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#9825e730bc1f8535a763ce054f72fba587e4d12b"
+source = "git+https://github.com/pop-os/libcosmic.git#3c5a2d9340ca80836ce947cad8cc4c0fb1157355"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -6914,9 +6914,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
+checksum = "af310deaae937e48a26602b730250b4949e125f468f11e6990be3e5304ddd96f"
 
 [[package]]
 name = "xmlwriter"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2666,7 +2666,8 @@ impl Application for App {
                     })
                     .on_middle_click(move || Message::MiddleClick(pane, Some(entity_middle_click)))
                     .opacity(self.config.opacity_ratio())
-                    .padding(space_xxs);
+                    .padding(space_xxs)
+                    .show_headerbar(self.config.show_headerbar);
 
                 if self.config.focus_follow_mouse {
                     terminal_box = terminal_box.on_mouse_enter(move || Message::MouseEnter(pane));

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -50,6 +50,7 @@ pub struct TerminalBox<'a, Message> {
     id: Option<Id>,
     border: Border,
     padding: Padding,
+    show_headerbar: bool,
     click_timing: Duration,
     context_menu: Option<Point>,
     on_context_menu: Option<Box<dyn Fn(Option<Point>) -> Message + 'a>>,
@@ -70,6 +71,7 @@ where
             id: None,
             border: Border::default(),
             padding: Padding::new(0.0),
+            show_headerbar: true,
             click_timing: Duration::from_millis(500),
             context_menu: None,
             on_context_menu: None,
@@ -93,6 +95,11 @@ where
 
     pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
         self.padding = padding.into();
+        self
+    }
+
+    pub fn show_headerbar(mut self, show_headerbar: bool) -> Self {
+        self.show_headerbar = show_headerbar;
         self
     }
 
@@ -281,7 +288,11 @@ where
                 Quad {
                     bounds: layout.bounds(),
                     border: Border {
-                        radius: [0.0, 0.0, radius_s, radius_s].into(),
+                        radius: if self.show_headerbar {
+                            [0.0, 0.0, radius_s, radius_s].into()
+                        } else {
+                            [radius_s, radius_s, radius_s, radius_s].into()
+                        },
                         width: self.border.width,
                         color: self.border.color,
                     },


### PR DESCRIPTION
This rounds the upper `terminal_box` corners if the header bar is hidden and updates libcosmic to prevent the box being cropped by context drawers.