### PR TITLE
Fix broken numlock behavior

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -693,10 +693,11 @@ where
         match event {
             Event::Keyboard(KeyEvent::KeyPressed {
                 key: Key::Named(named),
+                modified_key: Key::Named(modified_named),
                 modifiers,
                 text,
                 ..
-            }) if state.is_focused => {
+            }) if state.is_focused && named == modified_named => {
                 for key_bind in self.key_binds.keys() {
                     if key_bind.matches(modifiers, &Key::Named(named)) {
                         return Status::Captured;


### PR DESCRIPTION
libcosmic broke backwards compatibility in pop-os/libcosmic@0491c4b
Add comparison with modified_key to ensure only actual named keys are processed as such.

This is related to pop-os/libcosmic#702