### PR TITLE
Add very basic custom keybinding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "env_logger 0.10.2",
  "fork",
  "hex_color",
+ "home",
  "i18n-embed",
  "i18n-embed-fl",
  "icu_collator",
@@ -1293,6 +1294,7 @@ dependencies = [
  "ron 0.8.1",
  "rust-embed",
  "serde",
+ "serde_yaml",
  "shlex",
  "tokio",
  "url",
@@ -5251,6 +5253,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,6 +6084,12 @@ name = "unix_permissions_ext"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7497808a85e03f612f13e9c5061e4c81cdee86e6c00adfa1096690990ccd08e9"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ icu_collator = "1.5"
 icu_provider = { version = "1.5", features = ["sync"] }
 rust-embed = "8"
 url = "2.5"
+serde_yaml = "0.9.34"
+home = "0.5.9"
 
 [dependencies.cosmic-files]
 git = "https://github.com/pop-os/cosmic-files.git"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,19 @@ back to using `softbuffer` and `tiny-skia`.
 
 Custom color schemes can be imported from the `View -> Color schemes...` menu item.
 You can find templates for color schemes in the [color-schemes](color-schemes) folder.
+
+## Keyboard Shortcuts
+
+Custom key bindings can be configured in `~/.config/cosmic-term/cosmic-term.yaml`.  
+Currently, only single-character keys are supported—keys like `"ArrowLeft"`, `"Enter"`, or `"Backspace"` are not yet available.
+
+#### Example
+```yaml
+key_bindings:
+  - key: V   # Pressing Ctrl+Shift+Super+Alt+V pastes
+    mods: Ctrl|Shift|Super|Alt
+    action: Paste
+    
+  - key: F   # Pressing Alt+F zooms in
+    mods: Alt
+    action: ZoomIn

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -1,12 +1,30 @@
 use cosmic::widget::menu::key_bind::{KeyBind, Modifier};
 use cosmic::{iced::keyboard::Key, iced_core::keyboard::key::Named};
+use home::home_dir;
+use serde::{Deserialize, Serialize};
+use serde_yaml;
 use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
 
 use crate::Action;
 
-//TODO: load from config
+#[derive(Debug, Deserialize, Serialize)]
+struct RawCustomConfig {
+    key_bindings: Vec<RawCustomKeyBinding>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RawCustomKeyBinding {
+    key: String,
+    mods: String,
+    action: String,
+}
+
+//TODO: this function is called way too often
 pub fn key_binds() -> HashMap<KeyBind, Action> {
-    let mut key_binds = HashMap::new();
+    let mut key_binds: HashMap<KeyBind, Action> = HashMap::new();
 
     macro_rules! bind {
         ([$($modifier:ident),+ $(,)?], $key:expr, $action:ident) => {{
@@ -78,5 +96,65 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     // CTRL+Alt+L clears the scrollback.
     bind!([Ctrl, Alt], Key::Character("L".into()), ClearScrollback);
 
+    // overwrite defaults
+
+    let raw_config: RawCustomConfig;
+
+    if let Some(home) = home_dir() {
+        let path = home
+            .join(".config")
+            .join("cosmic-term")
+            .join("cosmic-term.yaml");
+
+        match load_config(path) {
+            Ok(config) => raw_config = config,
+
+            Err(e) => {
+                log::error!("error loading keybind config: {:?}", e);
+                return key_binds;
+            }
+        }
+    } else {
+        return key_binds;
+    }
+
+    // for now only allow to overwrite actions that already have a key bind by default
+    let mut valid_actions: HashMap<String, Action> = HashMap::new();
+    for value in key_binds.values() {
+        valid_actions.insert(format!("{value:?}"), *value);
+    }
+
+    'outer: for raw_key_binding in raw_config.key_bindings.iter() {
+        if !(valid_actions.contains_key(&raw_key_binding.action)) {
+            continue;
+        }
+        // TODO: use named keys
+        if raw_key_binding.key.chars().count() != 1 {
+            continue;
+        }
+
+        let mut custom_key_bind = KeyBind {
+            modifiers: vec![],
+            key: Key::Character(raw_key_binding.key.as_str().into()),
+        };
+
+        for modifier in raw_key_binding.mods.split('|') {
+            match modifier.to_lowercase().as_str() {
+                "alt" => custom_key_bind.modifiers.push(Modifier::Alt),
+                "ctrl" => custom_key_bind.modifiers.push(Modifier::Ctrl),
+                "shift" => custom_key_bind.modifiers.push(Modifier::Shift),
+                "super" => custom_key_bind.modifiers.push(Modifier::Super),
+                _ => continue 'outer,
+            }
+        }
+        key_binds.insert(custom_key_bind, valid_actions[&raw_key_binding.action]);
+    }
+
     key_binds
+}
+
+fn load_config(path: PathBuf) -> Result<RawCustomConfig, Box<dyn std::error::Error>> {
+    let content: String = fs::read_to_string(path)?; // Read file into a string
+    let config: RawCustomConfig = serde_yaml::from_str(&content)?; // Deserialize YAML into rust struct
+    Ok(config)
 }


### PR DESCRIPTION
The shortcuts are read from a yaml file located at `~/.config/cosmic-term/cosmic-term.yaml`.
Keys that would have to be accessed using `Key::Named()` are not yet supported.

I am new to contributing so I am open to suggestions :D