### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=d218c76#d218c76b58c7a3b20dd5e7943f93fc306a1b81b8"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=178eb0b#178eb0b14a0e5c192f64f6dee6c40341a8e5ee51"
 dependencies = [
  "cosmic-protocols",
  "libc",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1190,7 +1190,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1199,17 +1199,17 @@ dependencies = [
 [[package]]
 name = "cosmic-files"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-files.git#fbaf94fc948dd182c501e9a59bc6b6d962f24014"
+source = "git+https://github.com/pop-os/cosmic-files.git#912f8ca4db82c9a9effbc3a751c33b1f332809fc"
 dependencies = [
  "chrono",
  "dirs",
- "env_logger 0.11.6",
+ "env_logger",
  "flate2",
- "fork",
+ "fork 0.1.23",
  "freedesktop_entry_parser",
  "glob",
- "i18n-embed",
- "i18n-embed-fl",
+ "i18n-embed 0.14.1",
+ "i18n-embed-fl 0.7.0",
  "icu_collator",
  "icu_provider",
  "ignore",
@@ -1243,8 +1243,8 @@ dependencies = [
 
 [[package]]
 name = "cosmic-freedesktop-icons"
-version = "0.2.6"
-source = "git+https://github.com/pop-os/freedesktop-icons#a43b510bee3a77bb29098e10c8e23c2735cfb774"
+version = "0.3.0"
+source = "git+https://github.com/pop-os/freedesktop-icons#98f78d49022c893be2e974e95d95aaea963a6833"
 dependencies = [
  "dirs",
  "ini_core",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=d218c76#d218c76b58c7a3b20dd5e7943f93fc306a1b81b8"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=178eb0b#178eb0b14a0e5c192f64f6dee6c40341a8e5ee51"
 dependencies = [
  "bitflags 2.8.0",
  "wayland-backend",
@@ -1275,15 +1275,15 @@ dependencies = [
  "alacritty_terminal",
  "cosmic-files",
  "cosmic-text",
- "env_logger 0.10.2",
- "fork",
+ "env_logger",
+ "fork 0.2.0",
  "hex_color",
- "i18n-embed",
- "i18n-embed-fl",
+ "i18n-embed 0.15.3",
+ "i18n-embed-fl 0.9.3",
  "icu_collator",
  "icu_provider",
  "indexmap",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "libcosmic",
  "log",
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.12.1"
-source = "git+https://github.com/pop-os/cosmic-text.git#1f97cbd74795cc214b489ebc4dc574ef46c12843"
+source = "git+https://github.com/pop-os/cosmic-text.git#9125dd48b771e9aa7833d106a9850e935f71eaa6"
 dependencies = [
  "bitflags 2.8.0",
  "fontdb 0.16.2",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "almost",
  "cosmic-config",
@@ -1502,6 +1502,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1754,19 +1768,6 @@ checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -2092,6 +2093,15 @@ name = "fork"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e74d3423998a57e9d906e49252fb79eb4a04d5cdfe188fb1b7ff9fc076a8ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fork"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05dc8b302e04a1c27f4fe694439ef0f29779ca4edc205b7b58f00db04e29656d"
 dependencies = [
  "libc",
 ]
@@ -2562,22 +2572,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "i18n-embed"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0454970a5853f498e686cbd7bf9391aac2244928194780cb7a0af0f41937db6"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "locale_config",
+ "log",
+ "parking_lot 0.12.3",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
 name = "i18n-embed-fl"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc1f8715195dffc4caddcf1cf3128da15fe5d8a137606ea8856c9300047d5a2"
 dependencies = [
- "dashmap",
+ "dashmap 5.5.3",
  "find-crate",
  "fluent",
  "fluent-syntax",
  "i18n-config",
- "i18n-embed",
+ "i18n-embed 0.14.1",
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
+ "syn 2.0.96",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7578cee2940492a648bd60fb49ca85ee8c821a63790e0ef5b604cfed353b2a"
+dependencies = [
+ "dashmap 6.1.0",
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed 0.15.3",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
  "syn 2.0.96",
  "unic-langid",
 ]
@@ -2621,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2639,7 +2690,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2648,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
@@ -2672,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "futures",
  "iced_core",
@@ -2698,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "bitflags 2.8.0",
  "bytemuck",
@@ -2720,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -2732,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "bytes",
  "dnd",
@@ -2747,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -2763,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.8.0",
@@ -2794,7 +2845,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2812,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -3195,17 +3246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3232,9 +3272,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3401,7 +3441,7 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 [[package]]
 name = "libcosmic"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#fdfd80f8b133f3a1240a122489310146a224a7a7"
+source = "git+https://github.com/pop-os/libcosmic.git#1f826e38b9572fcd37b10caf0f8b53f2d64e34d4"
 dependencies = [
  "apply",
  "ashpd 0.9.2",
@@ -4260,9 +4300,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "open"
@@ -4649,6 +4689,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dependencies]
 alacritty_terminal = { git = "https://github.com/alacritty/alacritty", rev = "cacdb5bb3b72bad2c729227537979d95af75978f" }
-env_logger = "0.10"
+env_logger = "0.11"
 hex_color = { version = "3", features = ["serde"] }
 indexmap = "2"
 #TODO: for repeat_n, which is in std in 1.82
-itertools = "0.13"
+itertools = "0.14"
 lazy_static = "1"
 log = "0.4"
-open = "5.0.2"
+open = "5.3.2"
 palette = { version = "0.7", features = ["serde"] }
 paste = "1.0"
 ron = "0.8"
@@ -26,11 +26,11 @@ serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
 # Internationalization
-i18n-embed = { version = "0.14", features = [
+i18n-embed = { version = "0.15", features = [
     "fluent-system",
     "desktop-requester",
 ] }
-i18n-embed-fl = "0.7"
+i18n-embed-fl = "0.9"
 icu_collator = "1.5"
 icu_provider = { version = "1.5", features = ["sync"] }
 rust-embed = "8"
@@ -50,7 +50,7 @@ default-features = false
 features = ["a11y", "multi-window", "tokio", "winit"]
 
 [target.'cfg(unix)'.dependencies]
-fork = "0.1"
+fork = "0.2"
 
 [features]
 default = ["wgpu"]


### PR DESCRIPTION
Considerably reduces memory usage of cosmic-term, especially after clearing the terminal.