### PR TITLE
Add CLI arguments 2 - version, help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1313,7 @@ name = "cosmic-term"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
+ "clap",
  "cosmic-files",
  "cosmic-text",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
+# CLI arguments
+clap = { version = "4", features = ["derive"] }
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ mod terminal_theme;
 
 mod dnd;
 
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
 }
@@ -80,6 +82,19 @@ pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
 /// Runs application with these settings
 #[rustfmt::skip]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Add CLI arguments managements with `clap`
+    let matches = clap::Command::new("cosmic-term")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("COSMIC Terminal Emulator")
+        .long_about("A terminal emulator designed to be part of the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-term.")
+        .get_matches();
+
+    // Argument verification
+    if matches.contains_id("version") {
+        println!("cosmic-term {}", APP_VERSION);
+        return Ok(());
+    }
+    
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut parse_flags = true;


### PR DESCRIPTION
This is my implementation of support for the --version and -v arguments in cosmic-term, directly within the main.rs file.

Clap is a better choice for command-line argument parsing as it automatically handles common features like version management (--version) and help documentation (--help), without requiring manual imports. It also accesses cargo.toml by itself.

Clap offers a flexible argument management system, allowing easy definition of arguments, flags, subcommands, and custom validation. It could serve as a standard for COSMIC apps, as it provides features others may need anyway.

If this approach is deemed acceptable, it will be applied to all COSMIC apps.

Edit: Optimization is still possible and could happen soon. I have one version in the pipeline that add only 250 KB instead of 450 KB to the stripped executable, But I want to get this principle accepted first.
I plan to implement the optimized version to most cosmic-app.