### PR TITLE
Add --version and --help with clap_lex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,33 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,7 +1273,6 @@ name = "cosmic-term"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
- "clap",
  "cosmic-files",
  "cosmic-text",
  "env_logger",
@@ -1314,6 +1286,7 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
+ "lexopt",
  "libcosmic",
  "log",
  "open",
@@ -3460,6 +3433,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
  "unix_permissions_ext",
  "url",
  "uzers",
- "vergen",
+ "vergen 8.3.2",
  "walkdir",
  "xdg-mime",
  "zip",
@@ -1290,7 +1290,8 @@ dependencies = [
  "shlex",
  "tokio",
  "url",
- "vergen",
+ "vergen 8.3.2",
+ "vergen 9.0.4",
 ]
 
 [[package]]
@@ -1544,6 +1545,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6224,6 +6256,29 @@ dependencies = [
  "cfg-if",
  "rustversion",
  "time",
+]
+
+[[package]]
+name = "vergen"
+version = "9.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d2f179f8075b805a43a2a21728a46f0cc2921b3c58695b28fa8817e103cd9a"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1300,7 @@ name = "cosmic-term"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
+ "clap",
  "cosmic-files",
  "cosmic-text",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ shlex = "1"
 tokio = { version = "1", features = ["sync"] }
 # CLI arguments
 lexopt = "0.3.0"
-vergen = "9"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
 # CLI arguments
-clap = "4"
+lexopt = "0.3.0"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
 # CLI arguments
-lexopt = "0.3.0"
+clap_lex = "0.7"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
+# CLI arguments
+clap = "4"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ shlex = "1"
 tokio = { version = "1", features = ["sync"] }
 # CLI arguments
 lexopt = "0.3.0"
+vergen = "9"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 return Ok(());
             }
             Some("--no-daemon") => {
-                // Only disable daemonization under Redox
-                if cfg!(target_os = "redox") {
-                    daemonize = false;
-                }
+                daemonize = false;
             }
             Some("-e") | Some("--command") => {
                 // Handle the '--command' or '-e' flag

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,8 @@ mod terminal_theme;
 
 mod dnd;
 
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
 }
@@ -80,6 +82,19 @@ pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
 /// Runs application with these settings
 #[rustfmt::skip]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Add CLI arguments managements with `clap`
+    let matches = clap::Command::new("cosmic-term")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("COSMIC Terminal Emulator")
+        .long_about("A terminal emulator designed to be part of the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-term.")
+        .get_matches();
+
+    // Argument verification
+    if matches.contains_id("version") {
+        println!("cosmic-term {}", APP_VERSION);
+        return Ok(());
+    }
+
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut parse_flags = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,10 +68,25 @@ mod terminal_theme;
 
 mod dnd;
 
+use lexopt::{Parser, Arg};
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
+}
+
+fn print_help() {
+    println!(
+        r#"
+COSMIC Terminal
+A terminal emulator designed for the COSMIC desktop environment.
+
+Project home page: https://github.com/pop-os/cosmic-term
+
+Options:
+  --help     Show this message
+  --version  Show the version of cosmic-term"#
+    );
 }
 
 pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
@@ -82,19 +97,22 @@ pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
 /// Runs application with these settings
 #[rustfmt::skip]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Add CLI arguments managements with `clap`
-    let matches = clap::Command::new("cosmic-term")
-        .version(env!("CARGO_PKG_VERSION"))
-        .about("COSMIC Terminal Emulator")
-        .long_about("A terminal emulator designed to be part of the COSMIC desktop environment. \nFor more information, visit the GitHub repository at https://github.com/pop-os/cosmic-term.")
-        .get_matches();
+    let mut parser = Parser::from_env();
 
-    // Argument verification
-    if matches.contains_id("version") {
-        println!("cosmic-term {}", APP_VERSION);
-        return Ok(());
+    // Parse the arguments
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Arg::Long("help") => {
+                print_help();
+                return Ok(());
+            }
+            Arg::Long("version") => {
+                println!("cosmic-term {}", APP_VERSION);
+                return Ok(());
+            }
+            _ => {}
+        }
     }
-
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut parse_flags = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 print_help(env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"));
 		return Ok(());
             }
-            Some("--version") | Some("-v") => {
+            Some("--version") | Some("-V") => {
                 println!(
                     "cosmic-term {} (git commit {})",
                     env!("CARGO_PKG_VERSION"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,7 +182,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Terminal config setup
     let term_config = term::Config::default();
+    // Set up environmental variables for terminal
     tty::setup_env();
+    // Override TERM for better compatibility
     env::set_var("TERM", "xterm-256color");
 
     // Set settings

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             Some("-e") | Some("--command") => {
                 // Handle the '--command' or '-e' flag
-                continue;
+                break;
             }
             Some("--") => {
                 // End of flags, the next args are shell-related

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,19 +75,6 @@ lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
 }
 
-fn print_help() {
-    println!(
-        r#"COSMIC Terminal
-A terminal emulator designed for the COSMIC desktop environment.
-
-Project home page: https://github.com/pop-os/cosmic-term
-
-Options:
-  --help     Show this message
-  --version  Show the version of cosmic-term"#
-    );
-}
-
 pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
     let mut icon_cache = ICON_CACHE.lock().unwrap();
     icon_cache.get(name, size)
@@ -102,11 +89,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(arg) = parser.next()? {
         match arg {
             Arg::Short('h') | Arg::Long("help") => {
-                print_help();
-                return Ok(());
+                print_help(env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"));
+		return Ok(());
             }
             Arg::Short('v') | Arg::Long("version") => {
-                println!("cosmic-term {} (git commit {})",
+                println!(
+		    "cosmic-term {} (git commit {})",
                     env!("CARGO_PKG_VERSION"),
                     env!("VERGEN_GIT_SHA")
                 );
@@ -204,6 +192,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     cosmic::app::run::<App>(settings, flags)?;
 
     Ok(())
+}
+
+fn print_help() {
+    println!(
+        r#"COSMIC Terminal
+Designed for the COSMIC™ desktop environment, cosmic-term is a libcosmic-based terminal emulator.
+        
+Project home page: https://github.com/pop-os/cosmic-term
+
+Options:
+  --help     Show this message
+  --version  Show the version of cosmic-term"#
+    );
 }
 
 #[derive(Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ mod terminal_theme;
 
 mod dnd;
 
-use lexopt::{Parser, Arg};
+use lexopt::{Arg, Parser};
 
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             _ => {}
         }
     }
+    
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut parse_flags = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,9 @@ mod terminal_theme;
 
 mod dnd;
 
-use lexopt::{Arg, Parser};
+use clap_lex::RawArgs;
+
+use std::error::Error;
 
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
@@ -82,19 +84,20 @@ pub fn icon_cache_get(name: &'static str, size: u16) -> widget::icon::Icon {
 
 /// Runs application with these settings
 #[rustfmt::skip]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut parser = Parser::from_env();
+fn main() -> Result<(), Box<dyn Error>> {
+    let raw_args = RawArgs::from_args();
+    let mut cursor = raw_args.cursor();
 
     // Parse the arguments
-    while let Some(arg) = parser.next()? {
-        match arg {
-            Arg::Short('h') | Arg::Long("help") => {
+    while let Some(arg) = raw_args.next_os(&mut cursor) {
+        match arg.to_str() {
+            Some("--help") | Some("-h") => {
                 print_help(env!("CARGO_PKG_VERSION"), env!("VERGEN_GIT_SHA"));
 		return Ok(());
             }
-            Arg::Short('v') | Arg::Long("version") => {
+            Some("--version") | Some("-v") => {
                 println!(
-		    "cosmic-term {} (git commit {})",
+                    "cosmic-term {} (git commit {})",
                     env!("CARGO_PKG_VERSION"),
                     env!("VERGEN_GIT_SHA")
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,6 @@ mod terminal_theme;
 mod dnd;
 
 use lexopt::{Parser, Arg};
-const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 lazy_static::lazy_static! {
     static ref ICON_CACHE: Mutex<IconCache> = Mutex::new(IconCache::new());
@@ -78,8 +77,7 @@ lazy_static::lazy_static! {
 
 fn print_help() {
     println!(
-        r#"
-COSMIC Terminal
+        r#"COSMIC Terminal
 A terminal emulator designed for the COSMIC desktop environment.
 
 Project home page: https://github.com/pop-os/cosmic-term
@@ -103,18 +101,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the arguments
     while let Some(arg) = parser.next()? {
         match arg {
-            Arg::Long("help") => {
+            Arg::Short('h') | Arg::Long("help") => {
                 print_help();
                 return Ok(());
             }
-            Arg::Long("version") => {
-                println!("cosmic-term {}", APP_VERSION);
+            Arg::Short('v') | Arg::Long("version") => {
+                println!("cosmic-term {} (git commit {})",
+                    env!("CARGO_PKG_VERSION"),
+                    env!("VERGEN_GIT_SHA")
+                );
                 return Ok(());
             }
             _ => {}
         }
     }
-    
+
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut parse_flags = true;


### PR DESCRIPTION
This is a better version of my previous attempt.
This ensures that cosmic-term can provide its version and some information via the terminal.
This is essential for when multiple distributions start using COSMIC.

Clap has the benefit of managing the version automatically by reading Cargo.toml.

Note that my objective is to implement it in most COSMIC apps.