### PR TITLE
Add support for XF86Copy and XF86Paste keybindings

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -23,12 +23,14 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     // Standard key bindings
     bind!([Ctrl, Shift], Key::Character("A".into()), SelectAll);
     bind!([Ctrl, Shift], Key::Character("C".into()), Copy);
+    bind!([], Key::Named(Named::XF86Copy), Copy);
     bind!([Ctrl], Key::Character("c".into()), CopyOrSigint);
     bind!([Ctrl, Shift], Key::Character("F".into()), Find);
     bind!([Ctrl, Shift], Key::Character("N".into()), WindowNew);
     bind!([Ctrl, Shift], Key::Character("Q".into()), WindowClose);
     bind!([Ctrl, Shift], Key::Character("T".into()), TabNew);
     bind!([Ctrl, Shift], Key::Character("V".into()), Paste);
+    bind!([], Key::Named(Named::XF86Paste), Paste); 
     bind!([Shift], Key::Named(Named::Insert), PastePrimary);
     bind!([Ctrl, Shift], Key::Character("W".into()), TabClose);
     bind!([Ctrl], Key::Character(",".into()), Settings);


### PR DESCRIPTION
Keyboards with custom firmware that support dedicated "Copy" and "Paste" keycodes are more common now.

These keycodes solve a pain point with terminals: that you have to use Control+Shift+C/V to paste into the terminal, but Control+C/V everywhere else.

The dedicated Copy/Paste keycodes solve this problem by allowing you to use the same key combo in all apps that support it.

This patch supports the additional bindings by default while leaving the existing keybindings untouched.