### PR TITLE
feat: bind copy/paste keycodes to copy/paste actions.

### DIFF
--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -9,10 +9,10 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     let mut key_binds = HashMap::new();
 
     macro_rules! bind {
-        ([$($modifier:ident),+ $(,)?], $key:expr, $action:ident) => {{
+        ([$($modifier:ident),* $(,)?], $key:expr, $action:ident) => {{
             key_binds.insert(
                 KeyBind {
-                    modifiers: vec![$(Modifier::$modifier),+],
+                    modifiers: vec![$(Modifier::$modifier),*],
                     key: $key,
                 },
                 Action::$action,
@@ -23,12 +23,14 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     // Standard key bindings
     bind!([Ctrl, Shift], Key::Character("A".into()), SelectAll);
     bind!([Ctrl, Shift], Key::Character("C".into()), Copy);
+    bind!([], Key::Named(Named::Copy), Copy);
     bind!([Ctrl], Key::Character("c".into()), CopyOrSigint);
     bind!([Ctrl, Shift], Key::Character("F".into()), Find);
     bind!([Ctrl, Shift], Key::Character("N".into()), WindowNew);
     bind!([Ctrl, Shift], Key::Character("Q".into()), WindowClose);
     bind!([Ctrl, Shift], Key::Character("T".into()), TabNew);
     bind!([Ctrl, Shift], Key::Character("V".into()), Paste);
+    bind!([], Key::Named(Named::Paste), Paste);
     bind!([Shift], Key::Named(Named::Insert), PastePrimary);
     bind!([Ctrl, Shift], Key::Character("W".into()), TabClose);
     bind!([Ctrl], Key::Character(",".into()), Settings);


### PR DESCRIPTION
This PR replaces #478, which was not tested properly.

To add the keycodes bindings without modifiers, it was necessary to update the bind()
macro to support that. I followed the precedent from cosmic-files to do that. 

## Testing

 - Compiled cosmic-term, ran it, tested pasting with the Paste keycode.
