### PR TITLE
feat: configurable inner padding

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -40,6 +40,7 @@ syntax-dark = Color scheme dark
 syntax-light = Color scheme light
 default-zoom-step = Zoom steps
 opacity = Background opacity
+padding = Padding
 
 ### Font
 font = Font

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 
 use cosmic::{
     cosmic_config::{self, cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry},
-    theme,
+    cosmic_theme, theme,
 };
 use cosmic_text::{Metrics, Stretch, Weight};
 use hex_color::HexColor;
@@ -229,6 +229,7 @@ pub struct Config {
     pub font_stretch: u16,
     pub font_size_zoom_step_mul_100: u16,
     pub opacity: u8,
+    pub padding: u16,
     pub profiles: BTreeMap<ProfileId, Profile>,
     pub show_headerbar: bool,
     pub use_bright_bold: bool,
@@ -253,6 +254,7 @@ impl Default for Config {
             font_stretch: Stretch::Normal.to_number(),
             font_weight: Weight::NORMAL.0,
             opacity: 100,
+            padding: 8,
             profiles: BTreeMap::new(),
             show_headerbar: true,
             syntax_theme_dark: COSMIC_THEME_DARK.to_string(),
@@ -331,6 +333,14 @@ impl Config {
 
     pub fn opacity_ratio(&self) -> f32 {
         f32::from(self.opacity) / 100.0
+    }
+
+    pub fn padding_value(&self, space_xxs: u16) -> u16 {
+        if self.padding <= space_xxs {
+            u16::from(space_xxs)
+        } else {
+            u16::from(self.padding)
+        }
     }
 
     // Get a sorted and adjusted for duplicates list of profile names and ids

--- a/src/config.rs
+++ b/src/config.rs
@@ -254,7 +254,7 @@ impl Default for Config {
             font_stretch: Stretch::Normal.to_number(),
             font_weight: Weight::NORMAL.0,
             opacity: 100,
-            padding: 8,
+            padding: AppTheme::System.theme().cosmic().space_xxs(),
             profiles: BTreeMap::new(),
             show_headerbar: true,
             syntax_theme_dark: COSMIC_THEME_DARK.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 
 use cosmic::{
     cosmic_config::{self, cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry},
-    cosmic_theme, theme,
+    theme,
 };
 use cosmic_text::{Metrics, Stretch, Weight};
 use hex_color::HexColor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,7 @@ pub enum Message {
     Modifiers(Modifiers),
     MouseEnter(pane_grid::Pane),
     Opacity(u8),
+    Padding(u16),
     PaneClicked(pane_grid::Pane),
     PaneDragged(pane_grid::DragEvent),
     PaneFocusAdjacent(pane_grid::Direction),
@@ -1021,6 +1022,8 @@ impl App {
     }
 
     fn settings(&self) -> Element<Message> {
+        let cosmic_theme::Spacing { space_xxs, .. } = self.core().system_theme().cosmic().spacing;
+
         let app_theme_selected = match self.config.app_theme {
             AppTheme::Dark => 1,
             AppTheme::Light => 2,
@@ -1110,6 +1113,15 @@ impl App {
                     .control(widget::slider(0..=100, self.config.opacity, |opacity| {
                         Message::Opacity(opacity)
                     })),
+            )
+            .add(
+                widget::settings::item::builder(fl!("padding"))
+                    .description(format!("{}px", self.config.padding))
+                    .control(widget::slider(
+                        space_xxs..=100,
+                        self.config.padding,
+                        |padding| Message::Padding(padding),
+                    )),
             );
 
         let mut font_section = widget::settings::section()
@@ -2058,6 +2070,9 @@ impl Application for App {
             Message::Opacity(opacity) => {
                 config_set!(opacity, cmp::min(100, opacity));
             }
+            Message::Padding(padding) => {
+                config_set!(padding, cmp::min(100, padding));
+            }
             Message::PaneClicked(pane) => {
                 self.pane_model.set_focus(pane);
                 return self.update_title(Some(pane));
@@ -2701,7 +2716,7 @@ impl Application for App {
                     .on_window_focused(|| Message::WindowFocused)
                     .on_window_unfocused(|| Message::WindowUnfocused)
                     .opacity(self.config.opacity_ratio())
-                    .padding(space_xxs)
+                    .padding(self.config.padding_value(space_xxs))
                     .show_headerbar(self.config.show_headerbar);
 
                 if self.config.focus_follow_mouse {


### PR DESCRIPTION
Related to this issue https://github.com/pop-os/cosmic-term/issues/472

This was raised as a PR a while ago but I messed up the branches so I closed it and recreated it. Sorry about that!

This adds a slider for setting the padding of the terminal. It will respect the spacing setting as the minimum value.