### PR TITLE
Support ClI argument for Version and Help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1503,7 @@ name = "cosmic-term"
 version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
+ "clap_lex",
  "cosmic-files",
  "cosmic-text",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ ron = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
 tokio = { version = "1", features = ["sync"] }
+# CLI arguments
+clap_lex = "0.7"
 # Internationalization
 i18n-embed = { version = "0.15", features = [
     "fluent-system",


### PR DESCRIPTION
This ensures that cosmic-term can provide it's version and some information via the terminal.
This is essential for when multiple distributions start using COSMIC and won't update at the same time.

This is a cleaner version, my previous attempt had way too much commit for a simple feature...
 
It use Clap_lex