### PR TITLE
chore: stop depending on `itertools`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,7 +1518,6 @@ dependencies = [
  "icu_collator",
  "icu_provider 1.5.0",
  "indexmap",
- "itertools 0.14.0",
  "lazy_static",
  "libcosmic",
  "log",
@@ -3898,15 +3897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,7 +5696,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools 0.12.1",
+ "itertools",
  "libc",
  "libfuzzer-sys",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ alacritty_terminal = { git = "https://github.com/alacritty/alacritty", rev = "ca
 env_logger = "0.11"
 hex_color = { version = "3", features = ["serde"] }
 indexmap = "2"
-#TODO: for repeat_n, which is in std in 1.82
-itertools = "0.14"
 lazy_static = "1"
 log = "0.4"
 open = "5.3.2"

--- a/src/mouse_reporter.rs
+++ b/src/mouse_reporter.rs
@@ -224,9 +224,8 @@ impl MouseReporter {
         };
 
         //Generate term codes
-        //TODO: std::iter::repeat_n only available in 1.82
-        let x_iter = itertools::repeat_n(button_no_x, lines_x.unsigned_abs() as _);
-        let y_iter = itertools::repeat_n(button_no_y, lines_y.unsigned_abs() as _);
+        let x_iter = std::iter::repeat(lines_x.unsigned_abs()).take(button_no_x);
+        let y_iter = std::iter::repeat(lines_y.unsigned_abs()).take(button_no_y);
 
         x_iter
             .chain(y_iter)


### PR DESCRIPTION
As-salamu alaykum.

To comply with `rust-version = "1.80"`, a dependency on `itertools` was introduced, however, I see it as wasteful to add a dependency just to avoid writing `std::iter::repeat(_).take(_)` in favor of `itertools::repeat_n(_, _)`.

I [heard mmstick saying something similar](https://github.com/pop-os/cosmic-settings/pull/1258#issuecomment-3019743121), which means at least one person has the same mentality as me.