### PR TITLE
Reduce minimum underline thickness from 2px to 1px

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -434,7 +434,7 @@ where
                         }
 
                         if !metadata.flags.is_empty() {
-                            let style_line_height = (self.glyph_font_size / 10.0).clamp(2.0, 16.0);
+                            let style_line_height = (self.glyph_font_size / 10.0).clamp(1.0, 16.0);
 
                             let line_color = cosmic_text_to_iced_color(metadata.underline_color);
 


### PR DESCRIPTION
Migrated from Alacritty to COSMIC Term, and the first thing I noticed was that the underlines were especially thick. May just be personal preference, but I think they look better at 1px minimum than 2px (at least on my display).

Before:

<img width="484" height="403" alt="Screenshot_2025-08-13_19-34-09" src="https://github.com/user-attachments/assets/04175720-1159-4c4d-8f0d-5a0ee98c058e" />

After: 

<img width="484" height="406" alt="Screenshot_2025-08-13_19-34-17" src="https://github.com/user-attachments/assets/3a2ec4d6-d31f-4261-910c-0bed90f074fc" />
