### PR TITLE
Add configurable scrollback history

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -185,6 +185,13 @@ pub struct ColorScheme {
 #[serde(transparent)]
 pub struct ProfileId(pub u64);
 
+/// Same maximum as alacritty
+pub const MAX_SCROLLBACK_HISTORY: usize = 100_000;
+const DEFAULT_SCROLLBACK_HISTORY: usize = 10_000;
+fn default_scrollback_history() -> usize {
+    DEFAULT_SCROLLBACK_HISTORY
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Profile {
     pub name: String,
@@ -200,6 +207,8 @@ pub struct Profile {
     pub working_directory: String,
     #[serde(default)]
     pub hold: bool,
+    #[serde(default = "default_scrollback_history")]
+    pub scrollback_history: usize,
 }
 
 impl Default for Profile {
@@ -212,6 +221,8 @@ impl Default for Profile {
             tab_title: String::new(),
             working_directory: String::new(),
             hold: false,
+            // same default as alacritty,
+            scrollback_history: DEFAULT_SCROLLBACK_HISTORY,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1306,6 +1306,10 @@ impl App {
                                     .and_then(|profile_id| self.config.profiles.get(&profile_id))
                                 {
                                     Some(profile) => {
+                                        self.term_config.scrolling_history = Ord::min(
+                                            profile.scrollback_history,
+                                            crate::config::MAX_SCROLLBACK_HISTORY,
+                                        );
                                         let mut shell = None;
                                         if let Some(mut args) = shlex::split(&profile.command) {
                                             if !args.is_empty() {
@@ -1343,6 +1347,7 @@ impl App {
                                 .closable()
                                 .activate()
                                 .id();
+
                             match Terminal::new(
                                 current_pane,
                                 entity,


### PR DESCRIPTION
I have verified the feature works by dumping 20_000 and 200_000 lines. 
<img width="960" height="1048" alt="Screenshot from 2025-08-22 13-42-46" src="https://github.com/user-attachments/assets/698cfffa-f7ec-4432-9da9-41fdc54b95e5" />
<img width="1920" height="1048" alt="Screenshot from 2025-08-22 13-39-39" src="https://github.com/user-attachments/assets/24f1ee2a-7608-4b31-80b1-d9faecc04b88" />
