### PR TITLE
docs: Add minimal build guide for Ubuntu 24.04 (Wayland)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,23 @@ back to using `softbuffer` and `tiny-skia`.
 
 Custom color schemes can be imported from the `View -> Color schemes...` menu item.
 You can find templates for color schemes in the [color-schemes](color-schemes) folder.
+
+## Build on Ubuntu 24.04 LTS (Wayland) Minimal Dependencies
+
+After extensive testing, the minimal set of dependencies required to build `cosmic-term` on Ubuntu 24.04 (Wayland) is as follows:
+
+1.  **Install Minimal Dependencies:**
+    ```bash
+    sudo apt install libxkbcommon-dev libwayland-dev pkg-config libgl-dev libegl1-mesa-dev
+    ```
+
+2.  **Set PKG_CONFIG_PATH:**
+    The build requires the `PKG_CONFIG_PATH` to be explicitly set to resolve the `xkbcommon.pc` dependency. This step must be run in the terminal session before executing `cargo run`.
+    ```bash
+    export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig
+    ```
+
+3.  **Build and Run:**
+    ```bash
+    cargo run --release
+    ```


### PR DESCRIPTION
### Summary

This Pull Request adds a detailed, minimal dependency and build guide for users attempting to compile `cosmic-term` on **Ubuntu 24.04 LTS (Wayland)**.

The guide addresses the major blocker encountered during testing: the `xkbcommon.pc` file not being found by `pkg-config`, which requires an explicit `PKG_CONFIG_PATH` setting.

### Changes

- Adds a new section to `README.md` titled "Build on Ubuntu 24.04 LTS (Wayland) Minimal Dependencies".
- Lists the minimal `apt install` dependencies required for a successful build.
- Instructs the user to set the necessary `PKG_CONFIG_PATH` environment variable before compiling.

---

*(This contribution is the result of extensive testing to determine the minimal required packages.)*