### PR TITLE
i18n(ja): Update Japanese translation for better UX and clarity

### DIFF
--- a/i18n/ja/cosmic_term.ftl
+++ b/i18n/ja/cosmic_term.ftl
@@ -19,12 +19,12 @@ profiles = プロファイル
 name = 名前
 command-line = コマンドライン
 tab-title = タブタイトル
-tab-title-description = デフォルトのタブタイトルを無効にします
+tab-title-description = デフォルトのタブタイトルを上書きする
 add-profile = プロファイルを追加
 new-profile = 新しいプロファイル
 make-default = デフォルトにする
 working-directory = 作業ディレクトリ
-hold = 押さえる
+hold = 固定
 remain-open = 子プロセスが終了しても閉じない
 
 ## Settings
@@ -39,7 +39,7 @@ light = ライト
 syntax-dark = ダークシンタックスハイライト
 syntax-light = ライトシンタックスハイライト
 default-zoom-step = 拡大縮小の間隔
-opacity = 不透明度
+opacity = 透明度
 
 ### Font
 font = フォント


### PR DESCRIPTION
Fixes minor inaccuracies and a translation error in the existing Japanese translation file (i18n/ja/cosmic_term.ftl).

As a native Japanese speaker, I noticed these terms were unnatural or incorrect in a GUI context.

1.  **opacity**: Changed '不透明度' (hutoumeido) to **'透明度'** (toumeido). '透明度' is the standard, more natural term used in Japanese UI/UX.
2.  **hold**: Changed the unnatural '押さえる' (osaeru) to **'固定'** (kotei). This term is commonly used for 'pinning' or 'maintaining' a state in Japanese desktop environments.
3.  **tab-title-description**: Corrected the misinterpretation of **"Override"**. Changed the incorrect translation 'デフォルトのタブタイトルを無効にします' to **'デフォルトのタブタイトルを上書きする'** to accurately reflect the original English meaning.