### PR TITLE
Properly load/clear passwords on toggle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2661,6 +2661,15 @@ impl Application for App {
                     self.core.window.show_context = !self.core.window.show_context;
                     self.pane_model.update_terminal_focus();
 
+                    #[cfg(feature = "password_manager")]
+                    if ContextPage::PasswordManager == context_page {
+                        if self.core.window.show_context {
+                            self.password_mgr.pane = Some(self.pane_model.focused());
+                            return self.password_mgr.refresh_password_list();
+                        } else {
+                            self.password_mgr.clear();
+                        }
+                    }
                     return self.update_focus();
                 } else {
                     self.context_page = context_page;
@@ -2695,12 +2704,8 @@ impl Application for App {
 
                 #[cfg(feature = "password_manager")]
                 if ContextPage::PasswordManager == context_page {
-                    if self.core.window.show_context {
-                        self.password_mgr.pane = Some(self.pane_model.focused());
-                        return self.password_mgr.refresh_password_list();
-                    } else {
-                        self.password_mgr.clear();
-                    }
+                    self.password_mgr.pane = Some(self.pane_model.focused());
+                    return self.password_mgr.refresh_password_list();
                 }
             }
             Message::UpdateDefaultProfile((default, profile_id)) => {


### PR DESCRIPTION
Passwords were not loaded/cleared on toggling of the context page. This meant that passwords were kept in memory, which is bad. They were cleared when a password was selected, but then they were not loaded the next time the page was opened. 

This fixes that, so the page actually works as intended, and passwords are cleared when the page is closed. 