### PR TITLE
hold shift and click to add to selection

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1145,18 +1145,27 @@ where
                                 } else {
                                     TermSide::Right
                                 };
-                                let selection = match click_kind {
-                                    ClickKind::Single => {
-                                        Selection::new(SelectionType::Simple, location, side)
+                                // Check if shift is pressed and there's an existing selection to extend
+                                if state.modifiers.shift() {
+                                    let mut term = terminal.term.lock();
+                                    if let Some(ref mut selection) = term.selection {
+                                        selection.update(location, side);
+                                    } else {
+                                        term.selection =
+                                            Some(Selection::new(SelectionType::Simple, location, side));
                                     }
-                                    ClickKind::Double => {
-                                        Selection::new(SelectionType::Semantic, location, side)
-                                    }
-                                    ClickKind::Triple => {
-                                        Selection::new(SelectionType::Lines, location, side)
-                                    }
-                                };
-                                {
+                                } else {
+                                    let selection = match click_kind {
+                                        ClickKind::Single => {
+                                            Selection::new(SelectionType::Simple, location, side)
+                                        }
+                                        ClickKind::Double => {
+                                            Selection::new(SelectionType::Semantic, location, side)
+                                        }
+                                        ClickKind::Triple => {
+                                            Selection::new(SelectionType::Lines, location, side)
+                                        }
+                                    };
                                     let mut term = terminal.term.lock();
                                     term.selection = Some(selection);
                                 }


### PR DESCRIPTION
## Problem

The popos 22.04 terminal had the intuitive behavior that if a selection was made, then Shift was held and another part of the terminal was clicked, the selection would be expanded to include everything between the current selection and the Shift-clicked part

In contrast, cosmic-term simply deselects the current selection

## Solution

Make cosmic-term add to selection when Shift-clicking

## Testing

1. Make a selection
2. Hold shift and click elsewhere

on master it deselects

Here it adds to the selection