### PR TITLE
handle osc 8 links

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -246,6 +246,7 @@ pub struct Terminal {
     pub url_regex_search: RegexSearch,
     pub regex_matches: Vec<alacritty_terminal::term::search::Match>,
     pub active_regex_match: Option<alacritty_terminal::term::search::Match>,
+    pub active_hyperlink_id: Option<String>,
     bold_font_weight: Weight,
     buffer: Arc<Buffer>,
     is_focused: bool,
@@ -335,6 +336,7 @@ impl Terminal {
 
         Ok(Self {
             active_regex_match: None,
+            active_hyperlink_id: None,
             url_regex_search: url_regex_search(),
             regex_matches: Vec::new(),
             bold_font_weight: Weight(bold_font_weight),
@@ -884,6 +886,28 @@ impl Terminal {
 
                     if let Some(active_match) = &self.active_regex_match {
                         if active_match.contains(&indexed.point) {
+                            flags |= Flags::UNDERLINE;
+                        }
+                    }
+                    if let Some(active_id) = &self.active_hyperlink_id {
+                        let mut matches_active = indexed
+                            .cell
+                            .hyperlink()
+                            .is_some_and(|link| link.id() == active_id);
+                        if !matches_active
+                            && indexed.cell.flags.intersects(
+                                Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER,
+                            )
+                            && indexed.point.column.0 > 0
+                        {
+                            matches_active = grid[Point::new(
+                                indexed.point.line,
+                                Column(indexed.point.column.0 - 1),
+                            )]
+                            .hyperlink()
+                            .is_some_and(|link| link.id() == active_id);
+                        }
+                        if matches_active {
                             flags |= Flags::UNDERLINE;
                         }
                     }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -336,11 +336,7 @@ where
 
                     let location = terminal
                         .viewport_to_point(TermPoint::new(row as usize, TermColumn(col as usize)));
-                    if terminal
-                        .regex_matches
-                        .iter()
-                        .any(|bounds| bounds.contains(&location))
-                    {
+                    if get_hyperlink(&terminal, location).is_some() {
                         return mouse::Interaction::Pointer;
                     }
                 }
@@ -1002,7 +998,10 @@ where
             Event::Keyboard(KeyEvent::ModifiersChanged(modifiers)) => {
                 state.modifiers = modifiers;
 
-                if modifiers.contains(Modifiers::CTRL) || terminal.active_regex_match.is_some() {
+                if modifiers.contains(Modifiers::CTRL)
+                    || terminal.active_regex_match.is_some()
+                    || terminal.active_hyperlink_id.is_some()
+                {
                     //Might need to update the url regex highlight,
                     //so we need to calculate the mouse position
                     let location = if let Some(p) = cursor_position.position() {
@@ -1442,6 +1441,9 @@ fn get_hyperlink(
     terminal: &std::sync::MutexGuard<'_, Terminal>,
     location: TermPoint,
 ) -> Option<String> {
+    if let Some(link) = osc8_hyperlink_at(terminal, location) {
+        return Some(link.uri().to_string());
+    }
     if let Some(match_) = terminal
         .regex_matches
         .iter()
@@ -1452,6 +1454,32 @@ fn get_hyperlink(
     } else {
         None
     }
+}
+
+fn get_hyperlink_id(
+    terminal: &std::sync::MutexGuard<'_, Terminal>,
+    location: TermPoint,
+) -> Option<String> {
+    osc8_hyperlink_at(terminal, location).map(|link| link.id().to_string())
+}
+
+fn osc8_hyperlink_at(
+    terminal: &std::sync::MutexGuard<'_, Terminal>,
+    location: TermPoint,
+) -> Option<alacritty_terminal::term::cell::Hyperlink> {
+    let term = terminal.term.lock();
+    let grid = term.grid();
+    let cell = &grid[location];
+    if let Some(link) = cell.hyperlink() {
+        return Some(link);
+    }
+    if cell.flags.intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+        && location.column.0 > 0
+    {
+        let left = TermPoint::new(location.line, TermColumn(location.column.0 - 1));
+        return grid[left].hyperlink();
+    }
+    None
 }
 
 fn update_active_regex_match(
@@ -1466,6 +1494,9 @@ fn update_active_regex_match(
         return;
     }
 
+    let allow_hyperlink = modifiers
+        .map(|mods| mods.contains(Modifiers::CTRL))
+        .unwrap_or(false);
     //Require CTRL for keyboard and mouse interaction
     if let Some(modifiers) = modifiers {
         if !modifiers.contains(Modifiers::CTRL) {
@@ -1473,16 +1504,37 @@ fn update_active_regex_match(
                 terminal.active_regex_match = None;
                 terminal.needs_update = true;
             }
+            if terminal.active_hyperlink_id.is_some() {
+                terminal.active_hyperlink_id = None;
+                terminal.needs_update = true;
+            }
             return;
         }
+    } else if terminal.active_hyperlink_id.is_some() {
+        terminal.active_hyperlink_id = None;
+        terminal.needs_update = true;
     }
     let Some(location) = location else {
         if terminal.active_regex_match.is_some() {
             terminal.active_regex_match = None;
             terminal.needs_update = true;
         }
+        if terminal.active_hyperlink_id.is_some() {
+            terminal.active_hyperlink_id = None;
+            terminal.needs_update = true;
+        }
         return;
     };
+    if allow_hyperlink {
+        let next_hyperlink_id = get_hyperlink_id(terminal, location);
+        if terminal.active_hyperlink_id != next_hyperlink_id {
+            terminal.active_hyperlink_id = next_hyperlink_id;
+            terminal.needs_update = true;
+        }
+    } else if terminal.active_hyperlink_id.is_some() {
+        terminal.active_hyperlink_id = None;
+        terminal.needs_update = true;
+    }
     if let Some(match_) = terminal
         .regex_matches
         .iter()


### PR DESCRIPTION
## Problem

cosmic-term properly turns text like `https://...` or `file://...` into clickable links (hold Ctrl+hover to see highlighting; click to follow link). However, osc 8 links are not supported

Related to #595

## Solution

Add support for osc 8 links, keeping highlighting behavior the same as for existing links

## Testing

On both master and here these links will work:
```
echo 'file:///tmp'

echo 'https://github.com/pop-os/cosmic-term'
```

On master these links will not work, whereas they will in this branch:
```
printf '\033]8;;file:///tmp\033\\file-link\033]8;;\033\\ \033]8;;https://github.com/pop-os/cosmic-term\033\\http-link\033]8;;\033\\\n'
```