### PR TITLE
make new terminal open to same dir, not home

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -603,6 +603,14 @@ impl App {
         Task::none()
     }
 
+    fn active_terminal_cwd(&self) -> Option<std::path::PathBuf> {
+        let tab_model = self.pane_model.active()?;
+        let entity = tab_model.active();
+        let terminal = tab_model.data::<Mutex<Terminal>>(entity)?;
+        let terminal = terminal.lock().ok()?;
+        terminal.current_working_dir()
+    }
+
     fn save_color_schemes(&mut self, color_scheme_kind: ColorSchemeKind) -> Task<Message> {
         // Optimized for just saving color_schemes
         if let Some(ref config_handler) = self.config_handler {
@@ -2712,12 +2720,18 @@ impl Application for App {
                 }
             }
             Message::WindowNew => match env::current_exe() {
-                Ok(exe) => match process::Command::new(&exe).spawn() {
-                    Ok(_child) => {}
-                    Err(err) => {
-                        log::error!("failed to execute {:?}: {}", exe, err);
+                Ok(exe) => {
+                    let mut cmd = process::Command::new(&exe);
+                    if let Some(cwd) = self.active_terminal_cwd().filter(|path| path.is_dir()) {
+                        cmd.current_dir(cwd);
                     }
-                },
+                    match cmd.spawn() {
+                        Ok(_child) => {}
+                        Err(err) => {
+                            log::error!("failed to execute {:?}: {}", exe, err);
+                        }
+                    }
+                }
                 Err(err) => {
                     log::error!("failed to get current executable path: {}", err);
                 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -242,6 +242,7 @@ pub struct Terminal {
     pub needs_update: bool,
     pub profile_id_opt: Option<ProfileId>,
     pub tab_title_override: Option<String>,
+    child_pid: Option<u32>,
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub url_regex_search: RegexSearch,
     pub regex_matches: Vec<alacritty_terminal::term::search::Match>,
@@ -327,6 +328,20 @@ impl Terminal {
 
         let window_id = 0;
         let pty = tty::new(&options, size.into(), window_id)?;
+        let child_pid = {
+            #[cfg(unix)]
+            {
+                Some(pty.child().id())
+            }
+            #[cfg(windows)]
+            {
+                pty.child_watcher().pid().map(|pid| pid.get())
+            }
+            #[cfg(not(any(unix, windows)))]
+            {
+                None
+            }
+        };
 
         let pty_event_loop =
             EventLoop::new(term.clone(), event_proxy, pty, options.drain_on_exit, false)?;
@@ -341,6 +356,7 @@ impl Terminal {
             buffer: Arc::new(buffer),
             colors,
             context_menu: None,
+            child_pid,
             default_attrs,
             dim_font_weight: Weight(dim_font_weight),
             metadata_set,
@@ -391,6 +407,18 @@ impl Terminal {
 
     pub fn set_zoom_adj(&mut self, value: i8) {
         self.zoom_adj = value;
+    }
+
+    pub fn current_working_dir(&self) -> Option<std::path::PathBuf> {
+        #[cfg(target_os = "linux")]
+        {
+            let pid = self.child_pid?;
+            return std::fs::read_link(format!("/proc/{pid}/cwd")).ok();
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
     }
 
     pub fn redraw(&self) -> bool {


### PR DESCRIPTION
## Problem

Creating a new terminal, e.g. with `Ctrl + Shift + N`, opens to home dir.

popos 22.04 had a more intuitive behavior of opening to the cwd of the existing terminal. This is desirable because it is trivial to change to home dir (`cd`) but potentially a lot of typing to change dir to some deeply nested directory

## Solution

Grab existing terminal cwd and set new terminal to that