### PR TITLE
Allow overriding keybindings from config.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "accesskit",
  "accesskit_consumer",
  "atspi-common",
+ "cosmic-config",
  "serde",
  "thiserror 1.0.69",
  "zvariant 3.15.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ secret-service = { version = "5.1.0", features = [
 ], optional = true }
 thiserror = { version = "2.0", optional = true }
 secstr = { version = "0.5", optional = true }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 
 [dependencies.cosmic-files]
 git = "https://github.com/pop-os/cosmic-files.git"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ back to using `softbuffer` and `tiny-skia`.
 
 Custom color schemes can be imported from the `View -> Color schemes...` menu item.
 You can find templates for color schemes in the [color-schemes](color-schemes) folder.
+
+## Custom keybindings
+
+cosmic-term loads additional shortcuts from
+`~/.config/cosmic/com.system76.CosmicTerm/v1/keybindings`. The file uses the
+same format as cosmic-settings: each entry maps a keyboard binding to an action.
+
+Sample:
+
+```
+{
+    // Use Shift+Insert for Paste instead of PastePrimary.
+    (modifiers: [Shift], key: "Insert"): Paste,
+}
+```

--- a/src/key_bind.rs
+++ b/src/key_bind.rs
@@ -1,11 +1,77 @@
 use cosmic::widget::menu::key_bind::{KeyBind, Modifier};
 use cosmic::{iced::keyboard::Key, iced_core::keyboard::key::Named};
+use cosmic_config::{CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry};
+use ron::value::RawValue;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 use std::collections::HashMap;
 
 use crate::Action;
 
-//TODO: load from config
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, CosmicConfigEntry)]
+#[version = 1]
+pub struct KeyBindConfig {
+    #[serde(default)]
+    pub keybindings: KeyBindOverrides,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct KeyBindOverrides(HashMap<KeyBind, BindingAction>);
+
+impl KeyBindOverrides {
+    fn iter(&self) -> impl Iterator<Item = (&KeyBind, &BindingAction)> {
+        self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Serialize for KeyBindOverrides {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = HashMap::new();
+        for (key_bind, action) in &self.0 {
+            if let Some(ron) = KeyBindRon::from_key_bind(key_bind) {
+                map.insert(ron, *action);
+            }
+        }
+        map.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyBindOverrides {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map = HashMap::<KeyBindRon, BindingAction>::deserialize(deserializer)?;
+        let mut result = HashMap::with_capacity(map.len());
+        for (ron, action) in map {
+            let key_bind = KeyBind::try_from(ron).map_err(D::Error::custom)?;
+            result.insert(key_bind, action);
+        }
+        Ok(Self(result))
+    }
+}
+
 pub fn key_binds() -> HashMap<KeyBind, Action> {
+    default_key_binds()
+}
+
+pub fn key_binds_with_overrides(overrides: &KeyBindOverrides) -> HashMap<KeyBind, Action> {
+    let mut key_binds = default_key_binds();
+    if overrides.is_empty() {
+        return key_binds;
+    }
+
+    apply_overrides(&mut key_binds, overrides);
+    key_binds
+}
+
+fn default_key_binds() -> HashMap<KeyBind, Action> {
     let mut key_binds = HashMap::new();
 
     macro_rules! bind {
@@ -37,7 +103,6 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([], Key::Named(Named::F11), ToggleFullscreen);
 
     // Ctrl+Alt+D splits horizontally, Ctrl+Alt+R splits vertically, Ctrl+Shift+X maximizes split
-    //TODO: Adjust bindings as desired by UX
     bind!([Ctrl, Alt], Key::Character("d".into()), PaneSplitHorizontal);
     bind!([Ctrl, Alt], Key::Character("r".into()), PaneSplitVertical);
     bind!(
@@ -49,7 +114,6 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl, Alt], Key::Character("p".into()), PasswordManager);
 
     // Ctrl+Tab and Ctrl+Shift+Tab cycle through tabs
-    // Ctrl+Tab is not a special key for terminals and is free to use
     bind!([Ctrl], Key::Named(Named::Tab), TabNext);
     bind!([Ctrl, Shift], Key::Named(Named::Tab), TabPrev);
 
@@ -84,4 +148,221 @@ pub fn key_binds() -> HashMap<KeyBind, Action> {
     bind!([Ctrl, Alt], Key::Character("L".into()), ClearScrollback);
 
     key_binds
+}
+
+fn apply_overrides(key_binds: &mut HashMap<KeyBind, Action>, overrides: &KeyBindOverrides) {
+    for (binding, action) in overrides.iter() {
+        match action {
+            BindingAction::Action(mapped) => {
+                key_binds.insert(binding.clone(), *mapped);
+            }
+            BindingAction::Disable => {
+                key_binds.remove(binding);
+            }
+        }
+    }
+}
+
+fn key_to_string(key: &Key) -> Option<String> {
+    match key {
+        Key::Named(named) => named_to_string(named).map(|s| s.to_string()),
+        Key::Character(text) if !text.is_empty() => Some(text.to_string()),
+        _ => None,
+    }
+}
+
+fn string_to_key(name: &str) -> Option<Key> {
+    if name.chars().count() == 1 {
+        let ch = name.chars().next().unwrap();
+        return Some(Key::Character(ch.to_string().into()));
+    }
+    named_from_string(name).map(Key::Named)
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+struct KeyBindRon {
+    #[serde(default)]
+    modifiers: Vec<ModifierLabel>,
+    key: String,
+}
+
+impl KeyBindRon {
+    fn from_key_bind(key_bind: &KeyBind) -> Option<Self> {
+        let mut modifiers = key_bind
+            .modifiers
+            .iter()
+            .map(|m| ModifierLabel::from(*m))
+            .collect::<Vec<_>>();
+        modifiers.sort_by_key(|label| label.as_str());
+        let key = key_to_string(&key_bind.key)?;
+        Some(Self { modifiers, key })
+    }
+}
+
+impl TryFrom<KeyBindRon> for KeyBind {
+    type Error = String;
+
+    fn try_from(value: KeyBindRon) -> Result<Self, Self::Error> {
+        let modifiers = value
+            .modifiers
+            .into_iter()
+            .map(Modifier::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let key = string_to_key(&value.key).ok_or_else(|| "invalid key".to_string())?;
+        Ok(Self { modifiers, key })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+enum ModifierLabel {
+    Super,
+    Ctrl,
+    Alt,
+    Shift,
+}
+
+impl ModifierLabel {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Super => "Super",
+            Self::Ctrl => "Ctrl",
+            Self::Alt => "Alt",
+            Self::Shift => "Shift",
+        }
+    }
+}
+
+impl From<Modifier> for ModifierLabel {
+    fn from(value: Modifier) -> Self {
+        match value {
+            Modifier::Super => Self::Super,
+            Modifier::Ctrl => Self::Ctrl,
+            Modifier::Alt => Self::Alt,
+            Modifier::Shift => Self::Shift,
+        }
+    }
+}
+
+impl TryFrom<ModifierLabel> for Modifier {
+    type Error = String;
+
+    fn try_from(value: ModifierLabel) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ModifierLabel::Super => Modifier::Super,
+            ModifierLabel::Ctrl => Modifier::Ctrl,
+            ModifierLabel::Alt => Modifier::Alt,
+            ModifierLabel::Shift => Modifier::Shift,
+        })
+    }
+}
+
+fn named_to_string(named: &Named) -> Option<&'static str> {
+    macro_rules! named_map {
+        ($($variant:ident),+ $(,)?) => {
+            match named {
+                $(Named::$variant => Some(stringify!($variant)),)+
+                _ => None,
+            }
+        };
+    }
+
+    named_map![
+        Insert, Tab, ArrowLeft, ArrowRight, ArrowUp, ArrowDown, PageUp, PageDown, Home, End,
+        Delete, Backspace, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16,
+        F17, F18, F19, F20, F21, F22, F23, F24, Copy, Paste, Enter, Escape, Space, CapsLock
+    ]
+}
+
+fn named_from_string(name: &str) -> Option<Named> {
+    macro_rules! parse_named {
+        ($($variant:ident),+ $(,)?) => {
+            match name {
+                $(stringify!($variant) => Some(Named::$variant),)+
+                _ => None,
+            }
+        };
+    }
+
+    parse_named![
+        Insert, Tab, ArrowLeft, ArrowRight, ArrowUp, ArrowDown, PageUp, PageDown, Home, End,
+        Delete, Backspace, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16,
+        F17, F18, F19, F20, F21, F22, F23, F24, Copy, Paste, Enter, Escape, Space, CapsLock
+    ]
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) enum BindingAction {
+    Action(Action),
+    Disable,
+}
+
+impl<'de> Deserialize<'de> for BindingAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = Box::<RawValue>::deserialize(deserializer)?;
+        let text = raw.trim().get_ron().trim();
+
+        if text == "Disable" {
+            return Ok(Self::Disable);
+        }
+
+        match ron::from_str::<Action>(text) {
+            Ok(action) => Ok(Self::Action(action)),
+            Err(err) => Err(D::Error::custom(err.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ron::de::from_str;
+
+    fn shift_insert_key_bind() -> KeyBind {
+        KeyBind {
+            modifiers: vec![Modifier::Shift],
+            key: Key::Named(Named::Insert),
+        }
+    }
+
+    #[test]
+    fn defaults_include_shift_insert_paste_primary() {
+        let binds = key_binds();
+        assert_eq!(
+            binds.get(&shift_insert_key_bind()),
+            Some(&Action::PastePrimary)
+        );
+    }
+
+    #[test]
+    fn overrides_replace_default_binding() {
+        let overrides: KeyBindOverrides = from_str(
+            r#"{
+                (modifiers: [Shift], key: "Insert"): Paste,
+            }"#,
+        )
+        .unwrap();
+
+        let binds = key_binds_with_overrides(&overrides);
+
+        assert_eq!(binds.get(&shift_insert_key_bind()), Some(&Action::Paste));
+    }
+
+    #[test]
+    fn sample_config_file_parses_and_overrides() {
+        const SAMPLE: &str = r#"
+        {
+            // Use Shift+Insert for Paste instead of PastePrimary.
+            (modifiers: [Shift], key: "Insert"): Paste,
+        }
+        "#;
+
+        let overrides: KeyBindOverrides = from_str(SAMPLE).expect("sample config parses");
+        let binds = key_binds_with_overrides(&overrides);
+
+        assert_eq!(binds.get(&shift_insert_key_bind()), Some(&Action::Paste));
+    }
 }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -169,6 +169,14 @@ where
         self
     }
 
+    pub fn key_binds(mut self, key_binds: &HashMap<KeyBind, Action>) -> Self {
+        self.key_binds = key_binds
+            .iter()
+            .map(|(key, action)| (key.clone(), *action))
+            .collect();
+        self
+    }
+
     pub fn show_headerbar(mut self, show_headerbar: bool) -> Self {
         self.show_headerbar = show_headerbar;
         self
@@ -1151,8 +1159,11 @@ where
                                     if let Some(ref mut selection) = term.selection {
                                         selection.update(location, side);
                                     } else {
-                                        term.selection =
-                                            Some(Selection::new(SelectionType::Simple, location, side));
+                                        term.selection = Some(Selection::new(
+                                            SelectionType::Simple,
+                                            location,
+                                            side,
+                                        ));
                                     }
                                 } else {
                                     let selection = match click_kind {


### PR DESCRIPTION
Disclaimer:

I have basically 0 rust experience so I ended up using AI to generate the code. 

Notes:

This change is config only. It doesn't add any UI to enable changing the key bindings.  But this is usable as is, and UI is something that could be added later in a different change.

My personal goal was to enable re-mapping "Shift + Insert" to "Paste" from "PastePrimary", without having to maintain a fork.

The config file format should be similar to what comsic-settings and cosmic-comp use for their shortcuts, except that it uses KeyBinding from libcosmic as the map key and comsic-term's Action enum (instead of the Binding type and Action enum cosmic-settings uses).  But this should make the config familar to anyone familar with cosmic-settings shortcuts.

Here's a sample config:

```
// Example custom keybindings for cosmic-term.
// Save this file as ~/.config/cosmic/com.system76.CosmicTerm/v1/keybindings
{
    // Use Shift+Insert for Paste instead of PastePrimary.
    (modifiers: [Shift], key: "Insert"): Paste,
}
```

Key bindings can alos be disabled, such as

```
{
    (modifiers: [Shift], key: "Insert"): Disable,
}
```

I wasn't sure if it made sense to push modifications into libcomsic
(which would have increased the scope of the change), so I didn't.

KeyBind and Modifiers from libcomsic are not serializable, so I used
`KeyBindRon` and `ModifierLabel` to implement the serialization /
deserialization.

If you think it would be better to just make the libcosmic types
serializable, let me know, and I can try to hack that up.

Testing:

There's some super basic unit tests. I also manually tested both
overriding and disabling actions, as well as modfiying the config
while the terminal is working, and that all seems to work correctly.