### PR TITLE
Make scrollback history length configurable

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -27,6 +27,8 @@ make-default = Make default
 working-directory = Working directory
 hold = Hold
 remain-open = Remain open after child process exits.
+scrollback-history = Scrollback history
+scrollback-history-description = Maximum lines kept in scroll buffer (0-100,000). Changes apply to new terminals.
 
 ## Settings
 settings = Settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use crate::{fl, localize::LANGUAGE_SORTER};
 pub const CONFIG_VERSION: u64 = 1;
 pub const COSMIC_THEME_DARK: &str = "COSMIC Dark";
 pub const COSMIC_THEME_LIGHT: &str = "COSMIC Light";
+pub const DEFAULT_SCROLLBACK_HISTORY: u32 = 10_000;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum AppTheme {
@@ -200,6 +201,12 @@ pub struct Profile {
     pub working_directory: String,
     #[serde(default)]
     pub drain_on_exit: bool,
+    #[serde(default = "default_scrollback_history")]
+    pub scrollback_history: u32,
+}
+
+fn default_scrollback_history() -> u32 {
+    DEFAULT_SCROLLBACK_HISTORY
 }
 
 impl Default for Profile {
@@ -212,6 +219,7 @@ impl Default for Profile {
             tab_title: String::new(),
             working_directory: String::new(),
             drain_on_exit: false,
+            scrollback_history: DEFAULT_SCROLLBACK_HISTORY,
         }
     }
 }


### PR DESCRIPTION
## Summary

Add per-profile configurable scrollback history setting, allowing users to control how many lines of terminal output are retained in the scroll buffer.

Addresses #265.

Written with AI help.

<img width="489" height="456" alt="screenshot" src="https://github.com/user-attachments/assets/d46c8650-1094-4035-b4fd-0b5c272e999c" />

## Changes

### `src/config.rs`
- Add `DEFAULT_SCROLLBACK_HISTORY` constant (10,000 lines)
- Add `scrollback_history: u32` field to `Profile` struct with `#[serde(default)]` for backward compatibility

### `src/main.rs`
- Add `SCROLLBACK_HISTORY_VALUES` and `SCROLLBACK_HISTORY_NAMES` statics for dropdown options
- Add `Message::ProfileScrollbackHistory` variant and handler
- Add dropdown UI in profile settings
- Clone base `term_config` and override `scrolling_history` from profile when creating terminals

### `i18n/en/cosmic_term.ftl`
- Add `scrollback-history` and `scrollback-history-description` translations

## How It Works

1. Each profile stores its own `scrollback_history` value (default: 10,000)
2. Users select from predefined values via dropdown: 1,000 / 5,000 / 10,000 / 25,000 / 50,000 / 100,000
3. When creating a terminal, the base `term_config` is cloned and `scrolling_history` is overridden with the profile's value
4. Existing configs without the field use the default (serde default)

## Limitations

- Changes only apply to newly created terminals (alacritty_terminal limitation)
- Maximum 100,000 lines (alacritty's documented limit)

## Test Plan

- [x] Create a new profile and verify scrollback dropdown appears
- [x] Change scrollback value and open a new terminal with that profile
- [x] Generate output exceeding the limit and verify older lines are discarded
- [x] Verify existing configs load correctly with default value

## PR Template
- [x] I have disclosed use of any AI generated code in my commit messages.
If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
 - [x]  understand these changes in full and will be able to respond to review comments.
 - [x] My change is accurately described in the commit message.
 - [x] My contribution is tested and working as described.
- [x]  I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.