### PR TITLE
feat: emit CSI u-escape sequence for Shift+Enter

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -970,7 +970,11 @@ where
                         status = Status::Captured;
                     }
                     Named::Enter => {
-                        terminal.input_scroll(format!("{}{}", alt_prefix, "\x0D").into_bytes());
+                        if modifiers.shift() {
+                            terminal.input_scroll(format!("\x1b[13;{mod_no}u").into_bytes());
+                        } else {
+                            terminal.input_scroll(format!("{}{}", alt_prefix, "\x0D").into_bytes());
+                        }
                         status = Status::Captured;
                     }
                     Named::Escape => {


### PR DESCRIPTION
## Summary

- Shift+Enter now emits `\x1b[13;2u` (CSI u format) instead of `\x0D`, allowing CLI tools like Claude Code and Codex to distinguish Shift+Enter from plain Enter
- Matches behavior of Kitty, Ghostty, WezTerm, and iTerm2
- Plain Enter and Alt+Enter behavior unchanged

Closes #714

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
   - I'm a dev + know Rust, just used Claude to search libcosmic 
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.