### PR TITLE
Activate nearest tab only if closing focused tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2737,8 +2737,10 @@ impl Application for App {
                 if let Some(tab_model) = self.pane_model.active_mut() {
                     let entity = entity_opt.unwrap_or_else(|| tab_model.active());
 
-                    // Activate closest item
-                    if let Some(position) = tab_model.position(entity) {
+                    // Activate closest item if closing active tab
+                    if entity == tab_model.active()
+                        && let Some(position) = tab_model.position(entity)
+                    {
                         if position > 0 {
                             tab_model.activate_position(position - 1);
                         } else {


### PR DESCRIPTION
Closes: #719

The nearest tab should only be focused if the currently focused tab is closed.