### PR TITLE
implement open new tab in working dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "i18n-embed-fl",
  "icu",
  "indexmap 2.13.0",
+ "libc",
  "libcosmic",
  "log",
  "open",
@@ -4307,9 +4308,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libcosmic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ secret-service = { version = "5.1.0", features = [
 ], optional = true }
 thiserror = { version = "2.0", optional = true }
 secstr = { version = "0.5", optional = true }
+libc = "0.2.182"
 
 [dependencies.cosmic-files]
 git = "https://github.com/pop-os/cosmic-files.git"

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -29,6 +29,8 @@ make-default = Make default
 working-directory = Working directory
 hold = Hold
 remain-open = Remain open after child process exits.
+open-in-cwd = Use parent CWD
+open-in-cwd-description = Open new terminals using the focused tab's working directory.
 
 ## Settings
 settings = Settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,6 +200,8 @@ pub struct Profile {
     pub working_directory: String,
     #[serde(default)]
     pub drain_on_exit: bool,
+    #[serde(default)]
+    pub open_in_cwd: bool,
 }
 
 impl Default for Profile {
@@ -212,6 +214,7 @@ impl Default for Profile {
             tab_title: String::new(),
             working_directory: String::new(),
             drain_on_exit: false,
+            open_in_cwd: true,
         }
     }
 }

--- a/src/current_working_directory.rs
+++ b/src/current_working_directory.rs
@@ -1,0 +1,89 @@
+// based on https://github.com/alacritty/alacritty/blob/4225cea231432fb23442b1da2463b4ec9dfd726c/alacritty/src/daemon.rs#L117
+#[cfg(not(any(windows, target_os = "macos")))]
+use std::os::fd::AsFd;
+use std::path::PathBuf;
+
+use alacritty_terminal::tty::Pty;
+
+pub struct CWD {
+    #[cfg(not(any(windows, target_os = "macos")))]
+    master_fd: Option<std::os::fd::OwnedFd>,
+    #[cfg(not(any(windows, target_os = "macos")))]
+    shell_pid: u32,
+}
+
+impl CWD {
+    pub fn new(pty: &Pty) -> Self {
+        Self {
+            #[cfg(not(any(windows, target_os = "macos")))]
+            master_fd: pty.file().as_fd().try_clone_to_owned().ok(),
+            #[cfg(not(any(windows, target_os = "macos")))]
+            shell_pid: pty.child().id(),
+        }
+    }
+
+    pub fn current_working_directory(&self) -> Option<PathBuf> {
+        #[cfg(any(windows, target_os = "macos"))]
+        {
+            return None;
+        }
+
+        #[cfg(not(any(windows, target_os = "macos")))]
+        {
+            use std::os::fd::AsRawFd;
+
+            let fd = self.master_fd.as_ref()?.as_raw_fd();
+            foreground_process_path(fd, self.shell_pid).ok()
+        }
+    }
+}
+
+#[cfg(not(any(windows, target_os = "macos", target_os = "openbsd")))]
+pub fn foreground_process_path(
+    master_fd: std::os::fd::RawFd,
+    shell_pid: u32,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let mut pid = unsafe { libc::tcgetpgrp(master_fd) };
+    if pid < 0 {
+        pid = shell_pid as libc::pid_t;
+    }
+
+    let link_path = if cfg!(target_os = "freebsd") {
+        format!("/compat/linux/proc/{pid}/cwd")
+    } else {
+        format!("/proc/{pid}/cwd")
+    };
+
+    let cwd = std::fs::read_link(link_path)?;
+
+    Ok(cwd)
+}
+
+#[cfg(target_os = "openbsd")]
+pub fn foreground_process_path(
+    master_fd: RawFd,
+    shell_pid: u32,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let mut pid = unsafe { libc::tcgetpgrp(master_fd) };
+    if pid < 0 {
+        pid = shell_pid as libc::pid_t;
+    }
+    let name = [libc::CTL_KERN, libc::KERN_PROC_CWD, pid];
+    let mut buf = [0u8; libc::PATH_MAX as usize];
+    let result = unsafe {
+        libc::sysctl(
+            name.as_ptr(),
+            name.len().try_into().unwrap(),
+            buf.as_mut_ptr() as *mut _,
+            &mut buf.len() as *mut _,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if result != 0 {
+        Err(io::Error::last_os_error().into())
+    } else {
+        let foreground_path = unsafe { CStr::from_ptr(buf.as_ptr().cast()) }.to_str()?;
+        Ok(PathBuf::from(foreground_path))
+    }
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -29,6 +29,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     io, mem,
+    path::PathBuf,
     sync::{
         Arc, Mutex, Weak,
         atomic::{AtomicU32, Ordering},
@@ -41,6 +42,7 @@ pub use alacritty_terminal::grid::Scroll as TerminalScroll;
 
 use crate::{
     config::{ColorSchemeKind, Config as AppConfig, ProfileId},
+    current_working_directory::CWD,
     menu::MenuState,
     mouse_reporter::MouseReporter,
 };
@@ -260,6 +262,7 @@ pub struct Terminal {
     size: Size,
     use_bright_bold: bool,
     zoom_adj: i8,
+    cwd: CWD,
 }
 
 impl Terminal {
@@ -329,6 +332,8 @@ impl Terminal {
         let window_id = 0;
         let pty = tty::new(&options, size.into(), window_id)?;
 
+        let cwd = CWD::new(&pty);
+
         let pty_event_loop =
             EventLoop::new(term.clone(), event_proxy, pty, options.drain_on_exit, false)?;
         let notifier = Notifier(pty_event_loop.channel());
@@ -358,6 +363,7 @@ impl Terminal {
             use_bright_bold,
             zoom_adj: Default::default(),
             is_focused: true,
+            cwd,
         })
     }
 
@@ -1035,6 +1041,10 @@ impl Terminal {
                 delta,
             );
         }
+    }
+
+    pub fn current_working_directory(&self) -> Option<PathBuf> {
+        self.cwd.current_working_directory()
     }
 }
 /// Iterate over all visible regex matches.


### PR DESCRIPTION
continuation of https://github.com/pop-os/cosmic-term/pull/257

The cfgs are now in a dedicated file to not polute the codebase. But we still need them to support multiple os.

One problem is that the setting will be available on windows and macos, even tho the feature is not implemented. This will not cause a compile error tho, so ig it's ok. I could add a cfg in the ui code, but this will cause a warning, ect...

Lmk if the change looks good