### PR TITLE
feat: Add new keyboard-bindable action: clear and reset.

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -116,6 +116,7 @@ paste = Paste
 select-all = Select all
 find = Find
 clear-scrollback = Clear scrollback
+clear-and-reset = Clear and reset
 
 ## Open
 open-link = Open Link

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -83,6 +83,7 @@ pub fn context_menu<'a>(
         Element::from(menu_item(fl!("select-all"), Action::SelectAll)),
         Element::from(divider::horizontal::light()),
         Element::from(menu_item(fl!("clear-scrollback"), Action::ClearScrollback)),
+        Element::from(menu_item(fl!("clear-and-reset"), Action::ClearAndReset)),
         Element::from(divider::horizontal::light()),
         Element::from(menu_item(
             fl!("split-horizontal"),
@@ -238,6 +239,7 @@ pub fn menu_bar<'a>(
                         MenuItem::Button(fl!("select-all"), None, Action::SelectAll),
                         MenuItem::Divider,
                         MenuItem::Button(fl!("clear-scrollback"), None, Action::ClearScrollback),
+                        MenuItem::Button(fl!("clear-and-reset"), None, Action::ClearAndReset),
                         MenuItem::Divider,
                         MenuItem::Button(fl!("find"), None, Action::Find),
                     ],

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -58,6 +58,7 @@ impl Binding {
 pub enum KeyBindAction {
     Disable,
     ClearScrollback,
+    ClearAndReset,
     Copy,
     CopyOrSigint,
     Find,
@@ -100,6 +101,7 @@ impl KeyBindAction {
         match self {
             Self::Disable => None,
             Self::ClearScrollback => Some(Action::ClearScrollback),
+            Self::ClearAndReset => Some(Action::ClearAndReset),
             Self::Copy => Some(Action::Copy),
             Self::CopyOrSigint => Some(Action::CopyOrSigint),
             Self::Find => Some(Action::Find),
@@ -260,6 +262,7 @@ pub fn action_label(action: KeyBindAction) -> String {
     match action {
         KeyBindAction::Disable => fl!("disable"),
         KeyBindAction::ClearScrollback => fl!("clear-scrollback"),
+        KeyBindAction::ClearAndReset => fl!("clear-and-reset"),
         KeyBindAction::Copy => fl!("copy"),
         KeyBindAction::CopyOrSigint => fl!("copy-or-sigint"),
         KeyBindAction::Find => fl!("find"),
@@ -362,7 +365,7 @@ pub fn shortcut_groups() -> Vec<ShortcutGroup> {
             KeyBindAction::ZoomReset,
         ],
     });
-    let mut other_actions = vec![KeyBindAction::ClearScrollback];
+    let mut other_actions = vec![KeyBindAction::ClearScrollback, KeyBindAction::ClearAndReset];
     #[cfg(feature = "password_manager")]
     other_actions.push(KeyBindAction::PasswordManager);
     groups.push(ShortcutGroup {
@@ -499,6 +502,9 @@ fn fallback_shortcuts() -> Shortcuts {
 
     // CTRL+Alt+L clears the scrollback.
     bind!([Ctrl, Alt], "L", ClearScrollback);
+
+    // CTRL+Alt+K clears both the visible screen and scrollback.
+    bind!([Ctrl, Alt], "K", ClearAndReset);
 
     Shortcuts(shortcuts)
 }


### PR DESCRIPTION
Hi !

Added QOL feature I miss from previous terminal in pop-os, a simple reset on terminal to flush everything. It looks like some other miss it too ! So here is my contribution.

