### PR TITLE
fix: increase menu width to prevent cutting off toggle maximized

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -142,7 +142,7 @@ pub fn context_menu<'a>(
                 ..Default::default()
             }
         })
-        .width(Length::Fixed(240.0))
+        .width(Length::Fixed(360.0))
         .into()
 }
 


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Increases the menu width to 360 which matches cosmic-files to avoid the shortcut text for toggle maximized from going to the second line and being cut off. Fixes #467 

Before:
<img width="305" height="489" alt="image" src="https://github.com/user-attachments/assets/f934cfc5-d8fb-4535-b92c-9382b2db2ed6" />

After:
<img width="414" height="473" alt="image" src="https://github.com/user-attachments/assets/7c9aff9e-5669-40da-8cb1-1db79d2c4d6f" />