### PR TITLE
feat(ime): minimal IME support for the terminal_box widget

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1380,6 +1380,8 @@ where
                         }
                         shell.capture_event();
                     }
+                } else {
+                    state.is_focused = false;
                 }
             }
             Event::Mouse(MouseEvent::ButtonReleased(Button::Left)) => {

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -249,17 +249,25 @@ where
 
         // Draw cursor
         let cursor = terminal.term.lock().renderable_content().cursor;
-        let col = cursor.point.column.0;
+        let mut col = cursor.point.column.0;
         let line = cursor.point.line.0;
         let width = terminal.size().cell_width;
-        let height = terminal.size().cell_height;
-        let bottom_left = view_position
-            + Vector::new(
-                (col as f32 * width).floor(),
-                ((line + 1) as f32 * height).floor(),
-            );
+        let mut bottom_left = Vector::<f32>::ZERO;
+        terminal.with_buffer(|buffer| {
+            let layout = buffer.layout_runs().nth(line as usize).unwrap();
+            for glyph in layout.glyphs {
+                bottom_left.x += glyph.w;
+                let ch_width = if glyph.w > width { 2 } else { 1 };
+                if ch_width > col {
+                    break;
+                }
+                col -= ch_width;
+            }
+            bottom_left.y = layout.line_top + layout.line_height;
+        });
+
         InputMethod::Enabled {
-            cursor: Rectangle::new(bottom_left, Size::default()),
+            cursor: Rectangle::new(view_position + bottom_left, Size::default()),
             purpose: input_method::Purpose::Normal,
             preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -244,6 +244,9 @@ where
         if !state.is_focused {
             return InputMethod::Disabled;
         }
+        if let Some(_) = self.context_menu {
+            return InputMethod::Disabled;
+        }
 
         let view_position = layout.position() + [self.padding.left, self.padding.top].into();
 

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -252,22 +252,24 @@ where
         let mut col = cursor.point.column.0;
         let line = cursor.point.line.0;
         let width = terminal.size().cell_width;
-        let mut bottom_left = Vector::<f32>::ZERO;
+        let mut cursor_position = Vector::<f32>::ZERO;
+        let mut line_height = 0.0;
         terminal.with_buffer(|buffer| {
             let layout = buffer.layout_runs().nth(line as usize).unwrap();
             for glyph in layout.glyphs {
-                bottom_left.x += glyph.w;
+                cursor_position.x += glyph.w;
                 let ch_width = if glyph.w > width { 2 } else { 1 };
                 if ch_width > col {
                     break;
                 }
                 col -= ch_width;
             }
-            bottom_left.y = layout.line_top + layout.line_height;
+            cursor_position.y = layout.line_top;
+            line_height = layout.line_height;
         });
 
         InputMethod::Enabled {
-            cursor: Rectangle::new(view_position + bottom_left, Size::default()),
+            cursor: Rectangle::new(view_position + cursor_position, Size::new(1.0, line_height)),
             purpose: input_method::Purpose::Normal,
             preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -235,13 +235,31 @@ where
         self
     }
 
-    fn input_method<'b>(&self, state: &'b State, layout: Layout<'_>) -> InputMethod<&'b str> {
+    fn input_method<'b>(
+        &self,
+        state: &'b State,
+        layout: Layout<'_>,
+        terminal: &std::sync::MutexGuard<'_, Terminal>,
+    ) -> InputMethod<&'b str> {
         if !state.is_focused {
             return InputMethod::Disabled;
         }
 
+        let view_position = layout.position() + [self.padding.left, self.padding.top].into();
+
+        // Draw cursor
+        let cursor = terminal.term.lock().renderable_content().cursor;
+        let col = cursor.point.column.0;
+        let line = cursor.point.line.0;
+        let width = terminal.size().cell_width;
+        let height = terminal.size().cell_height;
+        let bottom_left = view_position
+            + Vector::new(
+                (col as f32 * width).floor(),
+                ((line + 1) as f32 * height).floor(),
+            );
         InputMethod::Enabled {
-            cursor: Rectangle::default(),
+            cursor: Rectangle::new(bottom_left, Size::default()),
             purpose: input_method::Purpose::Normal,
             preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }
@@ -892,7 +910,7 @@ where
                             shell.request_redraw();
                         }
                     }
-                    shell.request_input_method(&self.input_method(state, layout));
+                    shell.request_input_method(&self.input_method(state, layout, &terminal));
                 }
                 cosmic::iced::window::Event::Unfocused => {
                     state.is_focused = false;

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -244,7 +244,7 @@ where
         if !state.is_focused {
             return InputMethod::Disabled;
         }
-        if let Some(_) = self.context_menu {
+        if self.context_menu.is_some() {
             return InputMethod::Disabled;
         }
 
@@ -1207,10 +1207,8 @@ where
             }
             Event::InputMethod(event) => match event {
                 input_method::Event::Opened | input_method::Event::Closed => {
-                    state.preedit = matches!(event, input_method::Event::Opened).then(|| {
-                        let preedit = input_method::Preedit::new();
-                        preedit
-                    });
+                    state.preedit = matches!(event, input_method::Event::Opened)
+                        .then(input_method::Preedit::new);
                 }
                 input_method::Event::Preedit(content, selection) => {
                     if state.is_focused {

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -13,6 +13,7 @@ use cosmic::{
     iced::core::{
         Border, Shell,
         clipboard::Clipboard,
+        input_method::{self, InputMethod},
         keyboard::key::Named,
         layout::{self, Layout},
         renderer::{self, Quad, Renderer as _},
@@ -232,6 +233,18 @@ where
     pub fn disabled(mut self, disabled: bool) -> Self {
         self.disabled = disabled;
         self
+    }
+
+    fn input_method<'b>(&self, state: &'b State, layout: Layout<'_>) -> InputMethod<&'b str> {
+        if !state.is_focused {
+            return InputMethod::Disabled;
+        }
+
+        InputMethod::Enabled {
+            cursor: Rectangle::default(),
+            purpose: input_method::Purpose::Normal,
+            preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
+        }
     }
 }
 
@@ -879,6 +892,7 @@ where
                             shell.request_redraw();
                         }
                     }
+                    shell.request_input_method(&self.input_method(state, layout));
                 }
                 cosmic::iced::window::Event::Unfocused => {
                     state.is_focused = false;
@@ -1160,6 +1174,30 @@ where
                     }
                 }
             }
+            Event::InputMethod(event) => match event {
+                input_method::Event::Opened | input_method::Event::Closed => {
+                    state.preedit = matches!(event, input_method::Event::Opened).then(|| {
+                        let preedit = input_method::Preedit::new();
+                        preedit
+                    });
+                }
+                input_method::Event::Preedit(content, selection) => {
+                    if state.is_focused {
+                        let metrics = terminal.with_buffer(|buffer| buffer.metrics());
+                        state.preedit = Some(input_method::Preedit {
+                            content: content.to_owned(),
+                            selection: selection.clone(),
+                            text_size: Some(metrics.font_size.into()),
+                        })
+                    }
+                }
+                input_method::Event::Commit(text) => {
+                    if state.is_focused {
+                        terminal.paste(text.to_string());
+                        shell.capture_event();
+                    }
+                }
+            },
             Event::Mouse(MouseEvent::ButtonPressed(button)) => {
                 if let Some(p) = cursor_position.position_in(layout.bounds()) {
                     let x = p.x - self.padding.left;
@@ -1867,6 +1905,7 @@ pub struct State {
     scroll_pixels: f32,
     scrollbar_rect: Cell<Rectangle<f32>>,
     autoscroll: DragAutoscroll,
+    preedit: Option<input_method::Preedit>,
 }
 
 impl State {
@@ -1880,6 +1919,7 @@ impl State {
             scroll_pixels: 0.0,
             scrollbar_rect: Cell::new(Rectangle::default()),
             autoscroll: DragAutoscroll::new(AUTOSCROLL_INTERVAL),
+            preedit: None,
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/pop-os/cosmic-epoch/issues/2174

Fix the `cosmic-term` specific part of https://github.com/pop-os/cosmic-epoch/issues/2174.

The input method support in iced 14.0 requires text widgets to implement some logic to support input method input.

This PR includes this for the `cosmic-term` specific text widgets in `terminal_box.rs`.

https://github.com/user-attachments/assets/4bd0e0a0-eb5a-4089-b5b4-e943eaaca929

FYI, my old PR of backporting the IME feature may be a good reference to add IME support for an existing custom text widget. See `text_editor.rs`:
- https://github.com/pop-os/iced/pull/255/changes#diff-f50c40e421b597328bff5e029fc5734fe37f7a9b084ba39699a95cac1ab107b7

---

For text components other than `terminal_box`, the following PR will add IME support:
- https://github.com/pop-os/libcosmic/pull/1182

(I will force-push this branch to update my fork to rebase to newer upstream rev)

---

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.