### PR TITLE
feat: enable ctrl+enter, shift+enter CSI u-escaping

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -952,6 +952,9 @@ where
                     Named::F10 => csi("21", "~", mod_no),
                     Named::F11 => csi("23", "~", mod_no),
                     Named::F12 => csi("24", "~", mod_no),
+                    Named::Enter if modifiers.shift() || modifiers.control() => {
+                        csi("13", "u", mod_no)
+                    }
                     _ => None,
                 };
                 if let Some(escape_code) = escape_code {


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

