### PR TITLE
feat: Convert context menu from widget::popover to Wayland popup surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "atomicwrites",
  "cosmic-config-derive",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "cosmic-config-derive"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "quote",
  "syn",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "cosmic-files"
 version = "1.0.9"
-source = "git+https://github.com/pop-os/cosmic-files.git#d38d55525b5610e555e11a9c8ebc3bc8507d5480"
+source = "git+https://github.com/pop-os/cosmic-files.git#b17f8889a8a350a9a07ab3e00155d9b35f136152"
 dependencies = [
  "anyhow",
  "compio",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "cosmic-theme"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "almost",
  "configparser",
@@ -2963,7 +2963,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "dnd",
  "iced_accessibility",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "iced_accessibility"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2993,7 +2993,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
@@ -3017,7 +3017,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "futures",
  "iced_core",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -3083,7 +3083,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "bytes",
  "cosmic-client-toolkit",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -3115,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "as-raw-xcb-connection",
  "bitflags 2.11.0",
@@ -3146,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.2"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "cosmic-client-toolkit",
  "dnd",
@@ -3164,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "cosmic-client-toolkit",
  "cursor-icon",
@@ -4256,7 +4256,7 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 [[package]]
 name = "libcosmic"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/libcosmic.git#724351727a191516ca1b2f2f90a00b7d211c7e1f"
+source = "git+https://github.com/pop-os/libcosmic.git#a44cff8011d81209e18de86f24da248c88b5a28d"
 dependencies = [
  "apply",
  "ashpd 0.12.3",
@@ -6975,9 +6975,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -7032,9 +7032,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.13.1",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ features = ["monospace_fallback", "shape-run-cache"]
 git = "https://github.com/pop-os/libcosmic.git"
 default-features = false
 #TODO: a11y feature crashes file chooser dialog
-features = ["about", "multi-window", "tokio", "winit", "surface-message"]
+features = ["about", "autosize", "multi-window", "tokio", "winit", "surface-message"]
 
 [target.'cfg(unix)'.dependencies]
 fork = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -524,7 +524,13 @@ pub struct App {
     shortcut_search_regex: Option<regex::Regex>,
     shortcut_search_value: String,
     modifiers: Modifiers,
-    context_menu_popup: Option<(window::Id, pane_grid::Pane, segmented_button::Entity, Option<String>, widget::Id)>,
+    context_menu_popup: Option<(
+        window::Id,
+        pane_grid::Pane,
+        segmented_button::Entity,
+        Option<String>,
+        widget::Id,
+    )>,
     #[cfg(feature = "password_manager")]
     password_mgr: password_manager::PasswordManager,
 }
@@ -2835,7 +2841,8 @@ impl Application for App {
                                 let entity = tab_model.active();
                                 let link = menu_state.link.clone();
                                 let popup_id = window::Id::unique();
-                                self.context_menu_popup = Some((popup_id, pane, entity, link, widget::Id::unique()));
+                                self.context_menu_popup =
+                                    Some((popup_id, pane, entity, link, widget::Id::unique()));
 
                                 let main_window = self.core.main_window_id().unwrap();
                                 let pos_x = position.x as i32;
@@ -3274,12 +3281,14 @@ impl Application for App {
     }
 
     fn view_window(&self, window_id: window::Id) -> Element<'_, Message> {
-        if let Some((popup_id, _pane, entity, ref link, ref autosize_id)) = self.context_menu_popup {
+        if let Some((popup_id, _pane, entity, ref link, ref autosize_id)) = self.context_menu_popup
+        {
             if window_id == popup_id {
                 return widget::autosize::autosize(
                     menu::context_menu(&self.config, &self.key_binds, entity, link.clone()),
                     autosize_id.clone(),
-                ).into();
+                )
+                .into();
             }
         }
         match &self.dialog_opt {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3352,11 +3352,8 @@ impl Application for App {
                 // If a context menu popup is active for this pane, inform the
                 // terminal_box so it will emit on_context_menu(None) on click
                 // to dismiss the popup.
-                if let Some((_, popup_pane, _, _, _)) = &self.context_menu_popup {
-                    if pane == *popup_pane {
-                        terminal_box =
-                            terminal_box.context_menu(cosmic::iced::Point::ORIGIN);
-                    }
+                if self.context_menu_popup.is_some() {
+                    terminal_box = terminal_box.context_menu(cosmic::iced::Point::ORIGIN);
                 }
 
                 let tab_element: Element<'_, Message> = terminal_box.into();

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,6 +453,7 @@ pub enum Message {
     ZoomIn,
     ZoomOut,
     ZoomReset,
+    ContextMenuPopupClosed(window::Id),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -523,6 +524,7 @@ pub struct App {
     shortcut_search_regex: Option<regex::Regex>,
     shortcut_search_value: String,
     modifiers: Modifiers,
+    context_menu_popup: Option<(window::Id, pane_grid::Pane, segmented_button::Entity, Option<String>, widget::Id)>,
     #[cfg(feature = "password_manager")]
     password_mgr: password_manager::PasswordManager,
 }
@@ -1840,6 +1842,7 @@ impl Application for App {
             shortcut_search_regex: None,
             shortcut_search_value: String::new(),
             modifiers: Modifiers::empty(),
+            context_menu_popup: None,
             #[cfg(feature = "password_manager")]
             password_mgr: Default::default(),
         };
@@ -2428,40 +2431,18 @@ impl Application for App {
                 }
             }
             Message::CopyUrlByMenu => {
-                if let Some(tab_model) = self.pane_model.active() {
-                    let entity = tab_model.active();
-                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
-                        // Update context menu position
-                        let mut terminal = terminal.lock().unwrap();
-                        if let Some(url) =
-                            terminal.context_menu.as_ref().and_then(|m| m.link.as_ref())
-                        {
-                            let url = url.to_owned();
-                            terminal.context_menu = None;
-                            terminal.active_regex_match = None;
-                            terminal.needs_update = true;
-
-                            return Task::batch([clipboard::write(url), self.update_focus()]);
-                        }
+                if let Some((_, _, _, ref link, _)) = self.context_menu_popup {
+                    if let Some(url) = link.clone() {
+                        return Task::batch([clipboard::write(url), self.update_focus()]);
                     }
                 }
             }
             Message::LaunchUrlByMenu => {
-                if let Some(tab_model) = self.pane_model.active() {
-                    let entity = tab_model.active();
-                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
-                        // Update context menu position
-                        let mut terminal = terminal.lock().unwrap();
-                        if let Some(url) =
-                            terminal.context_menu.as_ref().and_then(|m| m.link.as_ref())
-                        {
-                            if let Err(err) = open::that_detached(url) {
-                                log::warn!("failed to open {:?}: {}", url, err);
-                            }
+                if let Some((_, _, _, ref link, _)) = self.context_menu_popup {
+                    if let Some(url) = link.as_ref() {
+                        if let Err(err) = open::that_detached(url) {
+                            log::warn!("failed to open {:?}: {}", url, err);
                         }
-                        terminal.context_menu = None;
-                        terminal.active_regex_match = None;
-                        terminal.needs_update = true;
                     }
                 }
             }
@@ -2810,54 +2791,91 @@ impl Application for App {
                 return self.update_title(None);
             }
             Message::TabContextAction(entity, action) => {
-                if let Some(tab_model) = self.pane_model.active() {
-                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
-                        // Close context menu
-                        {
-                            let mut terminal = terminal.lock().unwrap();
-                            //Some actions need the menu_state,
-                            //so only clear the position for them.
-                            match action {
-                                Action::LaunchUrlByMenu | Action::CopyUrlByMenu => {
-                                    if let Some(context_menu) = terminal.context_menu.as_mut() {
-                                        context_menu.position = None;
-                                    }
-                                }
-                                _ => {
-                                    terminal.context_menu = None;
-                                }
-                            }
-                        }
-                        // Run action's message
-                        return self.update(action.message(Some(entity)));
-                    }
+                // Close context menu popup
+                let mut tasks = Vec::new();
+                if let Some((popup_id, _, _, _, _)) = self.context_menu_popup.take() {
+                    tasks.push(cosmic::task::message(Message::Surface(
+                        cosmic::surface::action::destroy_popup(popup_id),
+                    )));
                 }
-            }
-            Message::TabContextMenu(pane, menu_state) => {
-                // Close any existing context menues
-                let panes: Vec<_> = self.pane_model.panes.iter().collect();
-                for (_pane, tab_model) in panes {
-                    let entity = tab_model.active();
+                // Also clear terminal context_menu state
+                if let Some(tab_model) = self.pane_model.active() {
                     if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
                         let mut terminal = terminal.lock().unwrap();
                         terminal.context_menu = None;
                     }
                 }
+                tasks.push(self.update(action.message(Some(entity))));
+                return cosmic::Task::batch(tasks);
+            }
+            Message::TabContextMenu(pane, menu_state) => {
+                let mut tasks = Vec::new();
 
-                // Show the context menu on the correct pane / terminal
-                if let Some(tab_model) = self.pane_model.panes.get(pane) {
-                    let entity = tab_model.active();
-                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
-                        // Update context menu position
-                        let mut terminal = terminal.lock().unwrap();
-                        terminal.context_menu = menu_state;
+                // Close existing context menu popup if any
+                if let Some((popup_id, _, _, _, _)) = self.context_menu_popup.take() {
+                    tasks.push(cosmic::task::message(Message::Surface(
+                        cosmic::surface::action::destroy_popup(popup_id),
+                    )));
+                }
+
+                // Clear all terminal context_menu state
+                for (_, tab_model) in self.pane_model.panes.iter() {
+                    for entity in tab_model.iter() {
+                        if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                            let mut terminal = terminal.lock().unwrap();
+                            terminal.context_menu = None;
+                        }
                     }
                 }
 
-                // Shift focus to the pane / terminal
-                // with the context menu
-                self.pane_model.set_focus(pane);
-                return self.update_title(Some(pane));
+                if let Some(menu_state) = menu_state {
+                    if let Some(position) = menu_state.position {
+                        if let Some(tab_model) = self.pane_model.panes.get(pane) {
+                            {
+                                let entity = tab_model.active();
+                                let link = menu_state.link.clone();
+                                let popup_id = window::Id::unique();
+                                self.context_menu_popup = Some((popup_id, pane, entity, link, widget::Id::unique()));
+
+                                let main_window = self.core.main_window_id().unwrap();
+                                let pos_x = position.x as i32;
+                                let pos_y = position.y as i32;
+
+                                tasks.push(cosmic::task::message(Message::Surface(
+                                    cosmic::surface::action::app_popup(move |_app: &mut Self| {
+                                        use cosmic::cctk::wayland_protocols::xdg::shell::client::xdg_positioner::{Anchor, Gravity};
+                                        use cosmic::iced_runtime::platform_specific::wayland::popup::{SctkPopupSettings, SctkPositioner};
+
+                                        SctkPopupSettings {
+                                            parent: main_window,
+                                            id: popup_id,
+                                            positioner: SctkPositioner {
+                                                size: None,
+                                                anchor_rect: cosmic::iced::Rectangle {
+                                                    x: pos_x,
+                                                    y: pos_y,
+                                                    width: 1,
+                                                    height: 1,
+                                                },
+                                                anchor: Anchor::None,
+                                                gravity: Gravity::BottomRight,
+                                                reactive: true,
+                                                ..Default::default()
+                                            },
+                                            parent_size: None,
+                                            grab: true,
+                                            close_with_children: false,
+                                            input_zone: None,
+                                        }
+                                    }, None),
+                                )));
+                            }
+                        }
+                    }
+                    self.pane_model.set_focus(pane);
+                }
+
+                return cosmic::Task::batch(tasks);
             }
             Message::TabNew => {
                 return self.create_and_focus_new_terminal(
@@ -3133,6 +3151,13 @@ impl Application for App {
                 self.reset_terminal_panes_zoom();
                 return self.update_config();
             }
+            Message::ContextMenuPopupClosed(id) => {
+                if let Some((popup_id, _, _, _, _)) = &self.context_menu_popup {
+                    if id == *popup_id {
+                        self.context_menu_popup = None;
+                    }
+                }
+            }
             Message::Surface(a) => {
                 return cosmic::task::message(cosmic::Action::Cosmic(
                     cosmic::app::Action::Surface(a),
@@ -3239,7 +3264,24 @@ impl Application for App {
         ]
     }
 
+    fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
+        if let Some((popup_id, _, _, _, _)) = &self.context_menu_popup {
+            if id == *popup_id {
+                return Some(Message::ContextMenuPopupClosed(id));
+            }
+        }
+        None
+    }
+
     fn view_window(&self, window_id: window::Id) -> Element<'_, Message> {
+        if let Some((popup_id, _pane, entity, ref link, ref autosize_id)) = self.context_menu_popup {
+            if window_id == popup_id {
+                return widget::autosize::autosize(
+                    menu::context_menu(&self.config, &self.key_binds, entity, link.clone()),
+                    autosize_id.clone(),
+                ).into();
+            }
+        }
         match &self.dialog_opt {
             Some(dialog) => dialog.view(window_id),
             None => widget::text("Unknown window ID").into(),
@@ -3307,26 +3349,17 @@ impl Application for App {
                     terminal_box = terminal_box.on_mouse_enter(move || Message::MouseEnter(pane));
                 }
 
-                let context_menu = {
-                    let terminal = terminal.lock().unwrap();
-                    terminal.context_menu.clone()
-                };
+                // If a context menu popup is active for this pane, inform the
+                // terminal_box so it will emit on_context_menu(None) on click
+                // to dismiss the popup.
+                if let Some((_, popup_pane, _, _, _)) = &self.context_menu_popup {
+                    if pane == *popup_pane {
+                        terminal_box =
+                            terminal_box.context_menu(cosmic::iced::Point::ORIGIN);
+                    }
+                }
 
-                let tab_element: Element<'_, Message> = match context_menu {
-                    Some(menu_state) => match menu_state.position {
-                        Some(point) => widget::popover(terminal_box.context_menu(point))
-                            .popup(menu::context_menu(
-                                &self.config,
-                                &self.key_binds,
-                                entity,
-                                menu_state.link,
-                            ))
-                            .position(widget::popover::Position::Point(point))
-                            .into(),
-                        None => terminal_box.into(),
-                    },
-                    None => terminal_box.into(),
-                };
+                let tab_element: Element<'_, Message> = terminal_box.into();
                 tab_column = tab_column.push(tab_element);
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -530,6 +530,7 @@ pub struct App {
         segmented_button::Entity,
         Option<String>,
         widget::Id,
+        cosmic::iced::Point,
     )>,
     #[cfg(feature = "password_manager")]
     password_mgr: password_manager::PasswordManager,
@@ -2437,14 +2438,14 @@ impl Application for App {
                 }
             }
             Message::CopyUrlByMenu => {
-                if let Some((_, _, _, ref link, _)) = self.context_menu_popup {
+                if let Some((_, _, _, ref link, _, _)) = self.context_menu_popup {
                     if let Some(url) = link.clone() {
                         return Task::batch([clipboard::write(url), self.update_focus()]);
                     }
                 }
             }
             Message::LaunchUrlByMenu => {
-                if let Some((_, _, _, ref link, _)) = self.context_menu_popup {
+                if let Some((_, _, _, ref link, _, _)) = self.context_menu_popup {
                     if let Some(url) = link.as_ref() {
                         if let Err(err) = open::that_detached(url) {
                             log::warn!("failed to open {:?}: {}", url, err);
@@ -2799,10 +2800,13 @@ impl Application for App {
             Message::TabContextAction(entity, action) => {
                 // Close context menu popup
                 let mut tasks = Vec::new();
-                if let Some((popup_id, _, _, _, _)) = self.context_menu_popup.take() {
-                    tasks.push(cosmic::task::message(Message::Surface(
-                        cosmic::surface::action::destroy_popup(popup_id),
-                    )));
+                if let Some((_popup_id, _, _, _, _, _)) = self.context_menu_popup.take() {
+                    #[cfg(feature = "wayland")]
+                    if is_wayland() {
+                        tasks.push(cosmic::task::message(Message::Surface(
+                            cosmic::surface::action::destroy_popup(_popup_id),
+                        )));
+                    }
                 }
                 // Also clear terminal context_menu state
                 if let Some(tab_model) = self.pane_model.active() {
@@ -2815,13 +2819,17 @@ impl Application for App {
                 return cosmic::Task::batch(tasks);
             }
             Message::TabContextMenu(pane, menu_state) => {
+                #[allow(unused_mut)]
                 let mut tasks = Vec::new();
 
                 // Close existing context menu popup if any
-                if let Some((popup_id, _, _, _, _)) = self.context_menu_popup.take() {
-                    tasks.push(cosmic::task::message(Message::Surface(
-                        cosmic::surface::action::destroy_popup(popup_id),
-                    )));
+                if let Some((_popup_id, _, _, _, _, _)) = self.context_menu_popup.take() {
+                    #[cfg(feature = "wayland")]
+                    if is_wayland() {
+                        tasks.push(cosmic::task::message(Message::Surface(
+                            cosmic::surface::action::destroy_popup(_popup_id),
+                        )));
+                    }
                 }
 
                 // Clear all terminal context_menu state
@@ -2835,18 +2843,26 @@ impl Application for App {
                 }
 
                 if let Some(menu_state) = menu_state {
-                    if let Some(position) = menu_state.position {
+                    if let Some(_position) = menu_state.position {
+                        let local_position = menu_state.local_position.unwrap_or(_position);
                         if let Some(tab_model) = self.pane_model.panes.get(pane) {
-                            {
-                                let entity = tab_model.active();
-                                let link = menu_state.link.clone();
-                                let popup_id = window::Id::unique();
-                                self.context_menu_popup =
-                                    Some((popup_id, pane, entity, link, widget::Id::unique()));
+                            let entity = tab_model.active();
+                            let link = menu_state.link.clone();
+                            let popup_id = window::Id::unique();
+                            self.context_menu_popup = Some((
+                                popup_id,
+                                pane,
+                                entity,
+                                link,
+                                widget::Id::unique(),
+                                local_position,
+                            ));
 
+                            #[cfg(feature = "wayland")]
+                            if is_wayland() {
                                 let main_window = self.core.main_window_id().unwrap();
-                                let pos_x = position.x as i32;
-                                let pos_y = position.y as i32;
+                                let pos_x = _position.x as i32;
+                                let pos_y = _position.y as i32;
 
                                 tasks.push(cosmic::task::message(Message::Surface(
                                     cosmic::surface::action::app_popup(move |_app: &mut Self| {
@@ -3159,7 +3175,7 @@ impl Application for App {
                 return self.update_config();
             }
             Message::ContextMenuPopupClosed(id) => {
-                if let Some((popup_id, _, _, _, _)) = &self.context_menu_popup {
+                if let Some((popup_id, _, _, _, _, _)) = &self.context_menu_popup {
                     if id == *popup_id {
                         self.context_menu_popup = None;
                     }
@@ -3272,7 +3288,7 @@ impl Application for App {
     }
 
     fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
-        if let Some((popup_id, _, _, _, _)) = &self.context_menu_popup {
+        if let Some((popup_id, _, _, _, _, _)) = &self.context_menu_popup {
             if id == *popup_id {
                 return Some(Message::ContextMenuPopupClosed(id));
             }
@@ -3281,7 +3297,8 @@ impl Application for App {
     }
 
     fn view_window(&self, window_id: window::Id) -> Element<'_, Message> {
-        if let Some((popup_id, _pane, entity, ref link, ref autosize_id)) = self.context_menu_popup
+        if let Some((popup_id, _pane, entity, ref link, ref autosize_id, _)) =
+            self.context_menu_popup
         {
             if window_id == popup_id {
                 return widget::autosize::autosize(
@@ -3365,7 +3382,42 @@ impl Application for App {
                     terminal_box = terminal_box.context_menu(cosmic::iced::Point::ORIGIN);
                 }
 
-                let tab_element: Element<'_, Message> = terminal_box.into();
+                let use_wayland_popup = {
+                    #[cfg(feature = "wayland")]
+                    {
+                        is_wayland()
+                    }
+                    #[cfg(not(feature = "wayland"))]
+                    {
+                        false
+                    }
+                };
+
+                let tab_element: Element<'_, Message> = if !use_wayland_popup {
+                    // Fallback: render context menu as an inline popover
+                    if let Some((_, popup_pane, popup_entity, ref link, _, point)) =
+                        self.context_menu_popup
+                    {
+                        if pane == popup_pane {
+                            let mut popover = widget::popover(terminal_box.context_menu(point));
+                            popover = popover
+                                .popup(menu::context_menu(
+                                    &self.config,
+                                    &self.key_binds,
+                                    popup_entity,
+                                    link.clone(),
+                                ))
+                                .position(widget::popover::Position::Point(point));
+                            popover.into()
+                        } else {
+                            terminal_box.into()
+                        }
+                    } else {
+                        terminal_box.into()
+                    }
+                } else {
+                    terminal_box.into()
+                };
                 tab_column = tab_column.push(tab_element);
             }
 
@@ -3518,4 +3570,12 @@ impl Application for App {
             },
         ])
     }
+}
+
+#[cfg(feature = "wayland")]
+fn is_wayland() -> bool {
+    matches!(
+        cosmic::app::cosmic::windowing_system(),
+        Some(cosmic::app::cosmic::WindowingSystem::Wayland)
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 
 use alacritty_terminal::{event::Event as TermEvent, term, term::color::Colors as TermColors, tty};
 use cosmic::iced::clipboard::dnd::DndAction;
-use cosmic::iced_core::keyboard::key::Named;
+use cosmic::iced::core::keyboard::key::Named;
 use cosmic::widget::menu::action::MenuAction;
 use cosmic::widget::menu::key_bind::KeyBind;
 use cosmic::widget::pane_grid::Pane;
@@ -2904,7 +2904,7 @@ impl Application for App {
                                 tasks.push(cosmic::task::message(Message::Surface(
                                     cosmic::surface::action::app_popup(move |_app: &mut Self| {
                                         use cosmic::cctk::wayland_protocols::xdg::shell::client::xdg_positioner::{Anchor, Gravity};
-                                        use cosmic::iced_runtime::platform_specific::wayland::popup::{SctkPopupSettings, SctkPositioner};
+                                        use cosmic::iced::runtime::platform_specific::wayland::popup::{SctkPopupSettings, SctkPositioner};
 
                                         SctkPopupSettings {
                                             parent: main_window,
@@ -3381,7 +3381,7 @@ impl Application for App {
                     )
                     .class(style::Container::Custom(Box::new(|theme| {
                         let cosmic = theme.cosmic();
-                        cosmic::iced_widget::container::Style {
+                        cosmic::iced::widget::container::Style {
                             icon_color: Some(Color::from(cosmic.background.on)),
                             text_color: Some(Color::from(cosmic.background.on)),
                             background: Some(iced::Background::Color(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2438,18 +2438,38 @@ impl Application for App {
                 }
             }
             Message::CopyUrlByMenu => {
-                if let Some((_, _, _, ref link, _, _)) = self.context_menu_popup {
-                    if let Some(url) = link.clone() {
-                        return Task::batch([clipboard::write(url), self.update_focus()]);
+                if let Some(tab_model) = self.pane_model.active() {
+                    let entity = tab_model.active();
+                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                        let mut terminal = terminal.lock().unwrap();
+                        if let Some(url) =
+                            terminal.context_menu.as_ref().and_then(|m| m.link.as_ref())
+                        {
+                            let url = url.to_owned();
+                            terminal.context_menu = None;
+                            terminal.active_regex_match = None;
+                            terminal.needs_update = true;
+
+                            return Task::batch([clipboard::write(url), self.update_focus()]);
+                        }
                     }
                 }
             }
             Message::LaunchUrlByMenu => {
-                if let Some((_, _, _, ref link, _, _)) = self.context_menu_popup {
-                    if let Some(url) = link.as_ref() {
-                        if let Err(err) = open::that_detached(url) {
-                            log::warn!("failed to open {:?}: {}", url, err);
+                if let Some(tab_model) = self.pane_model.active() {
+                    let entity = tab_model.active();
+                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                        let mut terminal = terminal.lock().unwrap();
+                        if let Some(url) =
+                            terminal.context_menu.as_ref().and_then(|m| m.link.as_ref())
+                        {
+                            if let Err(err) = open::that_detached(url) {
+                                log::warn!("failed to open {:?}: {}", url, err);
+                            }
                         }
+                        terminal.context_menu = None;
+                        terminal.active_regex_match = None;
+                        terminal.needs_update = true;
                     }
                 }
             }
@@ -2808,11 +2828,22 @@ impl Application for App {
                         )));
                     }
                 }
-                // Also clear terminal context_menu state
+                // Close terminal context menu state
                 if let Some(tab_model) = self.pane_model.active() {
                     if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
                         let mut terminal = terminal.lock().unwrap();
-                        terminal.context_menu = None;
+                        //Some actions need the menu_state,
+                        //so only clear the position for them.
+                        match action {
+                            Action::LaunchUrlByMenu | Action::CopyUrlByMenu => {
+                                if let Some(context_menu) = terminal.context_menu.as_mut() {
+                                    context_menu.position = None;
+                                }
+                            }
+                            _ => {
+                                terminal.context_menu = None;
+                            }
+                        }
                     }
                 }
                 tasks.push(self.update(action.message(Some(entity))));
@@ -2849,6 +2880,12 @@ impl Application for App {
                             let entity = tab_model.active();
                             let link = menu_state.link.clone();
                             let popup_id = window::Id::unique();
+
+                            if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                                let mut terminal = terminal.lock().unwrap();
+                                terminal.context_menu = Some(menu_state);
+                            }
+
                             self.context_menu_popup = Some((
                                 popup_id,
                                 pane,
@@ -3175,8 +3212,17 @@ impl Application for App {
                 return self.update_config();
             }
             Message::ContextMenuPopupClosed(id) => {
-                if let Some((popup_id, _, _, _, _, _)) = &self.context_menu_popup {
+                if let Some((popup_id, pane, entity, _, _, _)) = &self.context_menu_popup {
                     if id == *popup_id {
+                        // Clear link underline on the terminal
+                        if let Some(tab_model) = self.pane_model.panes.get(*pane) {
+                            if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(*entity) {
+                                let mut terminal = terminal.lock().unwrap();
+                                terminal.context_menu = None;
+                                terminal.active_regex_match = None;
+                                terminal.needs_update = true;
+                            }
+                        }
                         self.context_menu_popup = None;
                     }
                 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -7,8 +7,8 @@ use cosmic::widget::{Column, space};
 use cosmic::{
     Element,
     app::Core,
+    iced::core::Border,
     iced::{Background, Length, advanced::widget::text::Style as TextStyle},
-    iced_core::Border,
     theme,
     widget::{
         self, divider,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -26,6 +26,7 @@ static MENU_ID: LazyLock<cosmic::widget::Id> =
 #[derive(Debug, Clone)]
 pub struct MenuState {
     pub position: Option<Point>,
+    pub local_position: Option<Point>,
     pub link: Option<String>,
 }
 

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -2,8 +2,8 @@
 
 use cosmic::widget::menu::key_bind::{KeyBind, Modifier};
 use cosmic::{
+    iced::core::keyboard::key::Named,
     iced::keyboard::{Key, Modifiers},
-    iced_core::keyboard::key::Named,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -10,15 +10,7 @@ use alacritty_terminal::{
 use cosmic::{
     Renderer,
     cosmic_theme::palette::{WithAlpha, blend::Compose},
-    iced::{
-        Color, Element, Length, Padding, Point, Rectangle, Size, Vector,
-        advanced::graphics::text::Raw,
-        event::{Event, Status},
-        keyboard::{Event as KeyEvent, Key, Modifiers},
-        mouse::{self, Button, Event as MouseEvent, ScrollDelta},
-        window::RedrawRequest,
-    },
-    iced_core::{
+    iced::core::{
         Border, Shell,
         clipboard::Clipboard,
         keyboard::key::Named,
@@ -31,9 +23,17 @@ use cosmic::{
             tree,
         },
     },
+    iced::{
+        Color, Element, Length, Padding, Point, Rectangle, Size, Vector,
+        advanced::graphics::text::Raw,
+        event::{Event, Status},
+        keyboard::{Event as KeyEvent, Key, Modifiers},
+        mouse::{self, Button, Event as MouseEvent, ScrollDelta},
+        window::RedrawRequest,
+    },
     theme::Theme,
 };
-use cosmic::{iced_core::SmolStr, widget::menu::key_bind::KeyBind};
+use cosmic::{iced::core::SmolStr, widget::menu::key_bind::KeyBind};
 use cosmic_text::LayoutGlyph;
 use indexmap::IndexSet;
 use std::{

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1306,6 +1306,7 @@ where
                                         );
                                         shell.publish(on_context_menu(Some(MenuState {
                                             position: Some(abs),
+                                            local_position: Some(p),
                                             link,
                                         })));
                                     }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1300,8 +1300,12 @@ where
                                             None,
                                         );
                                         let link = get_hyperlink(&terminal, location);
+                                        let abs = cosmic::iced::Point::new(
+                                            layout.bounds().x + p.x,
+                                            layout.bounds().y + p.y,
+                                        );
                                         shell.publish(on_context_menu(Some(MenuState {
-                                            position: Some(p),
+                                            position: Some(abs),
                                             link,
                                         })));
                                     }


### PR DESCRIPTION
I tried to copy how context menu is done in cosmic-files.

before:
<img width="1011" height="443" alt="image" src="https://github.com/user-attachments/assets/927c877c-ef4a-49fb-9ef4-557c23c2a11f" />

after:
<img width="887" height="568" alt="image" src="https://github.com/user-attachments/assets/582264e7-6303-4b60-a5f2-0bd38fa4ba64" />


I asked in mattermost to see if it was intentional that context menu was kept that way. I didn't get a response, and assumed it wasn't.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

