### PR TITLE
fix: change zoom reset scope to active tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -596,6 +596,18 @@ impl App {
         }
     }
 
+    fn reset_active_pane_zoom(&mut self) {
+        if let Some(tab_model) = self.pane_model.active() {
+            for entity in tab_model.iter() {
+                if tab_model.is_active(entity)
+                    && let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity)
+                {
+                    terminal.lock().unwrap().set_zoom_adj(0);
+                }
+            }
+        }
+    }
+
     fn save_shortcuts_custom(&mut self) {
         self.config.shortcuts_custom = self.shortcuts_config.custom.clone();
         match &self.config_handler {
@@ -3197,7 +3209,7 @@ impl Application for App {
                 return self.update_render_active_pane_zoom(message);
             }
             Message::ZoomReset => {
-                self.reset_terminal_panes_zoom();
+                self.reset_active_pane_zoom();
                 return self.update_config();
             }
             Message::ContextMenuPopupClosed(id) => {


### PR DESCRIPTION
fixed inconsistensies with zoom. Added a separate function for resetting the zoom for the current tab, used it for the ctrl 0 shortcut.

Closes #794

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.