### PR TITLE
feat(font): add disable_ligatures toggle in advanced font settings

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -54,6 +54,7 @@ default-font-weight = Normal font weight
 default-dim-font-weight = Dim font weight
 default-bold-font-weight = Bold font weight
 use-bright-bold = Make bold text brighter
+disable-ligatures = Disable ligatures
 
 ### Splits
 splits = Splits

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,8 @@ pub struct Config {
     pub default_profile: Option<ProfileId>,
     #[serde(default)]
     pub shortcuts_custom: Shortcuts,
+    #[serde(default)]
+    pub disable_ligatures: bool,
 }
 
 impl Default for Config {
@@ -262,6 +264,7 @@ impl Default for Config {
             use_bright_bold: false,
             default_profile: None,
             shortcuts_custom: Shortcuts::default(),
+            disable_ligatures: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,6 +446,7 @@ pub enum Message {
     ToggleContextPage(ContextPage),
     UpdateDefaultProfile((bool, ProfileId)),
     UseBrightBold(bool),
+    DisableLigatures(bool),
     WindowClose,
     WindowNew,
     WindowFocused,
@@ -1464,6 +1465,10 @@ impl App {
                 .add(
                     widget::settings::item::builder(fl!("use-bright-bold"))
                         .toggler(self.config.use_bright_bold, Message::UseBrightBold),
+                )
+                .add(
+                    widget::settings::item::builder(fl!("disable-ligatures"))
+                        .toggler(self.config.disable_ligatures, Message::DisableLigatures),
                 );
             let padding = Padding {
                 top: 0.0,
@@ -2723,6 +2728,12 @@ impl Application for App {
             Message::UseBrightBold(use_bright_bold) => {
                 if use_bright_bold != self.config.use_bright_bold {
                     config_set!(use_bright_bold, use_bright_bold);
+                    return self.update_config();
+                }
+            }
+            Message::DisableLigatures(disable_ligatures) => {
+                if disable_ligatures != self.config.disable_ligatures {
+                    config_set!(disable_ligatures, disable_ligatures);
                     return self.update_config();
                 }
             }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -21,8 +21,8 @@ use cosmic::{
     widget::{pane_grid, segmented_button},
 };
 use cosmic_text::{
-    Attrs, AttrsList, Buffer, BufferLine, CacheKeyFlags, Family, LineEnding, Metrics, Shaping,
-    Weight, Wrap,
+    Attrs, AttrsList, Buffer, BufferLine, CacheKeyFlags, Family, FeatureTag, FontFeatures,
+    LineEnding, Metrics, Shaping, Weight, Wrap,
 };
 use indexmap::IndexSet;
 use std::{
@@ -53,6 +53,14 @@ pub const MIN_CURSOR_CONTRAST: f64 = 1.5;
 /// Duplicated from you guessed it.
 /// A regex expression can start or end outside the visible screen. Therefore, without this constant, some regular expressions would not match at the top and bottom.
 pub const MAX_SEARCH_LINES: usize = 100;
+
+fn no_ligature_features() -> FontFeatures {
+    let mut features = FontFeatures::new();
+    features.disable(FeatureTag::STANDARD_LIGATURES);
+    features.disable(FeatureTag::CONTEXTUAL_LIGATURES);
+    features.disable(FeatureTag::CONTEXTUAL_ALTERNATES);
+    features
+}
 
 /// https://github.com/alacritty/alacritty/blob/4a7728bf7fac06a35f27f6c4f31e0d9214e5152b/alacritty/src/config/ui_config.rs#L36-L39
 fn url_regex_search() -> RegexSearch {
@@ -259,6 +267,7 @@ pub struct Terminal {
     search_value: String,
     size: Size,
     use_bright_bold: bool,
+    disable_ligatures: bool,
     zoom_adj: i8,
 }
 
@@ -280,6 +289,7 @@ impl Terminal {
         let dim_font_weight = app_config.dim_font_weight;
         let bold_font_weight = app_config.bold_font_weight;
         let use_bright_bold = app_config.use_bright_bold;
+        let disable_ligatures = app_config.disable_ligatures;
 
         let metrics = Metrics::new(14.0, 21.0);
 
@@ -291,12 +301,16 @@ impl Terminal {
         let (default_metada_idx, _) = metadata_set.insert_full(default_metada);
 
         //TODO: set color to default fg
-        let default_attrs = Attrs::new()
+        let mut default_attrs = Attrs::new()
             .family(Family::Monospace)
             .weight(Weight(font_weight))
             .stretch(font_stretch)
             .color(default_fg)
             .metadata(default_metada_idx);
+
+        if disable_ligatures {
+            default_attrs = default_attrs.font_features(no_ligature_features());
+        }
 
         let mut buffer = Buffer::new_empty(metrics);
 
@@ -356,6 +370,7 @@ impl Terminal {
             tab_title_override,
             term,
             use_bright_bold,
+            disable_ligatures,
             zoom_adj: Default::default(),
             is_focused: true,
         })
@@ -623,6 +638,16 @@ impl Terminal {
 
         if self.use_bright_bold != config.use_bright_bold {
             self.use_bright_bold = config.use_bright_bold;
+            update_cell_size = true;
+        }
+
+        if self.disable_ligatures != config.disable_ligatures {
+            self.disable_ligatures = config.disable_ligatures;
+            self.default_attrs = if config.disable_ligatures {
+                self.default_attrs.clone().font_features(no_ligature_features())
+            } else {
+                self.default_attrs.clone().font_features(FontFeatures::new())
+            };
             update_cell_size = true;
         }
 


### PR DESCRIPTION
Closes #735.

Adds `Config.disable_ligatures` (default: `false`). When enabled, disables the OpenType `liga`, `clig`, and `calt` features on the terminal's default font attrs.

The toggle is exposed in **View > Settings > Font > Advanced font settings**, alongside the existing `Make bold text brighter` toggle, matching the location requested in the issue.

Changes propagate live to existing terminals through `Terminal::set_config`, so toggling does not require restarting tabs.

## Files

- `i18n/en/cosmic_term.ftl` — `disable-ligatures = Disable ligatures`
- `src/config.rs` — `disable_ligatures: bool` field, `#[serde(default)]`
- `src/main.rs` — `Message::DisableLigatures`, settings row, update handler
- `src/terminal.rs` — `no_ligature_features()` helper, applied in `new` and on live config change

## Verification

- `cargo check` passes
- Default behaviour unchanged when flag is `false`
- Toggle applies live without tab restart