### PR TITLE
bound the event channel to prevent unbounded RSS growth

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -438,7 +438,7 @@ pub enum Message {
     TabNext,
     TabPrev,
     TermEvent(pane_grid::Pane, segmented_button::Entity, TermEvent),
-    TermEventTx(mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>),
+    TermEventTx(mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>),
     ToggleFullscreen,
     ToggleContextPage(ContextPage),
     UpdateDefaultProfile((bool, ProfileId)),
@@ -503,7 +503,7 @@ pub struct App {
     find_search_id: widget::Id,
     find_search_value: String,
     term_event_tx_opt:
-        Option<mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
+        Option<mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
     startup_options: Option<tty::Options>,
     term_config: term::Config,
     color_scheme_errors: Vec<String>,
@@ -3623,7 +3623,7 @@ impl Application for App {
                 stream::channel(
                     100,
                     |mut output: iced::futures::channel::mpsc::Sender<Message>| async move {
-                        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+                        let (event_tx, mut event_rx) = mpsc::channel(1024);
                         output.send(Message::TermEventTx(event_tx)).await.unwrap();
 
                         while let Some((pane, entity, event)) = event_rx.recv().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -502,8 +502,7 @@ pub struct App {
     find: bool,
     find_search_id: widget::Id,
     find_search_value: String,
-    term_event_tx_opt:
-        Option<mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
+    term_event_tx_opt: Option<mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
     startup_options: Option<tty::Options>,
     term_config: term::Config,
     color_scheme_errors: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3622,6 +3622,10 @@ impl Application for App {
                 stream::channel(
                     100,
                     |mut output: iced::futures::channel::mpsc::Sender<Message>| async move {
+                        // Bounded: when the GUI can't drain fast enough, alacritty's PTY reader
+                        // blocks on send → kernel pipe fills → producing program is throttled by
+                        // the OS. Capacity 1024 caps the queue depth; per-event memory depends on
+                        // payload (Wakeup is ~100 B; Title/PtyWrite carry owned Strings).
                         let (event_tx, mut event_rx) = mpsc::channel(1024);
                         output.send(Message::TermEventTx(event_tx)).await.unwrap();
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -104,7 +104,10 @@ pub struct EventProxy(
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {
-        //TODO: handle error
+        // Bounded channel; blocking_send propagates backpressure to alacritty's
+        // PTY reader instead of letting events accumulate. Called from alacritty's
+        // std::thread PTY reader (not a tokio worker), so blocking is safe and
+        // blocking_send won't panic.
         let _ = self.2.blocking_send((self.0, self.1, event));
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -100,7 +100,7 @@ pub struct EventProxy(
     pane_grid::Pane,
     segmented_button::Entity,
     mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, Event)>,
-    );
+);
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -99,13 +99,13 @@ impl From<Size> for WindowSize {
 pub struct EventProxy(
     pane_grid::Pane,
     segmented_button::Entity,
-    mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, Event)>,
-);
+    mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, Event)>,
+    );
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {
         //TODO: handle error
-        let _ = self.2.send((self.0, self.1, event));
+        let _ = self.2.blocking_send((self.0, self.1, event));
     }
 }
 
@@ -270,7 +270,7 @@ impl Terminal {
     pub fn new(
         pane: pane_grid::Pane,
         entity: segmented_button::Entity,
-        event_tx: mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, Event)>,
+        event_tx: mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, Event)>,
         config: Config,
         options: Options,
         app_config: &AppConfig,


### PR DESCRIPTION
- [ X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X ] I understand these changes in full and will be able to respond to review comments.
- [ X ] My change is accurately described in the commit message.
- [ X] My contribution is tested and working as described.
- [ X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Fixes #805 

This changes the  mpsc::unbounded_channel() to a bound one with a cap of 1024 messages. I used 1024 here since that should be at max 100MB. I have built and tested this locally and the terminal is "locked up" but the machine is not. This to me seem to fix the issue, previously the terminal consumed all RAM on the system. 

AI Usage: Claude Code was used in the initial troubleshooting of the system problem and for code review. 

Test: 

run ```yes | head -c 1G``` in terminal to create messages. This only causes cosmic-term to become unresponsive and not the system, as seen previously. 

Btop output with local changes applied to cosmic-term: 

<img width="1202" height="612" alt="image" src="https://github.com/user-attachments/assets/6f6b4031-4b49-49a2-a62b-ca5e8b475624" />

