### PR TITLE
fix: suppress URL launch on drag-select and add scheme confirmation

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -91,6 +91,13 @@ shortcut-group-window = Window
 shortcut-group-zoom = Zoom
 shortcut-replace-body = { $binding } is already assigned to { $existing }. Replace it with { $new_action }?
 shortcut-replace-title = Replace shortcut?
+
+# Hyperlink launch confirmation
+launch-url-confirm-title = Open link?
+launch-url-confirm-body = This link uses an unusual scheme. Open it?
+
+    { $url }
+launch-url-open = Open
 tab-activate = Activate tab { $number }
 toggle-fullscreen = Toggle fullscreen
 type-to-search = Type to search...

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,6 +386,8 @@ pub enum Message {
     Key(Modifiers, Key),
     LaunchUrl(String),
     LaunchUrlByMenu,
+    LaunchUrlConfirm,
+    LaunchUrlCancel,
     Modifiers(Modifiers),
     ShortcutCaptureCancel,
     ShortcutCaptureStart(shortcuts::KeyBindAction),
@@ -513,6 +515,7 @@ pub struct App {
     color_scheme_tab_model: widget::segmented_button::SingleSelectModel,
     profile_expanded: Option<ProfileId>,
     show_advanced_font_settings: bool,
+    pending_launch_url: Option<String>,
     shortcut_capture: Option<shortcuts::KeyBindAction>,
     shortcut_conflict: Option<ShortcutConflict>,
     shortcut_conflict_overlay_restore: Option<bool>,
@@ -1874,6 +1877,7 @@ impl Application for App {
             color_scheme_rename_id: widget::Id::unique(),
             color_scheme_tab_model: widget::segmented_button::Model::default(),
             profile_expanded: None,
+            pending_launch_url: None,
             show_advanced_font_settings: false,
             shortcut_capture: None,
             shortcut_conflict: None,
@@ -1896,6 +1900,10 @@ impl Application for App {
 
     //TODO: currently the first escape unfocuses, and the second calls this function
     fn on_escape(&mut self) -> Task<Message> {
+        if self.pending_launch_url.take().is_some() {
+            return Task::none();
+        }
+
         if self.core.window.show_context {
             // Handle keyboard shortcut page escape
             if let ContextPage::KeyboardShortcuts = self.context_page {
@@ -2465,9 +2473,23 @@ impl Application for App {
                 }
             }
             Message::LaunchUrl(url) => {
-                if let Err(err) = open::that_detached(&url) {
+                if launch_url_scheme_is_safe(&url) {
+                    if let Err(err) = open::that_detached(&url) {
+                        log::warn!("failed to open {:?}: {}", url, err);
+                    }
+                } else {
+                    self.pending_launch_url = Some(url);
+                }
+            }
+            Message::LaunchUrlConfirm => {
+                if let Some(url) = self.pending_launch_url.take()
+                    && let Err(err) = open::that_detached(&url)
+                {
                     log::warn!("failed to open {:?}: {}", url, err);
                 }
+            }
+            Message::LaunchUrlCancel => {
+                self.pending_launch_url = None;
             }
             Message::CopyUrlByMenu => {
                 if let Some(tab_model) = self.pane_model.active() {
@@ -3335,6 +3357,22 @@ impl Application for App {
     }
 
     fn dialog(&self) -> Option<Element<'_, Message>> {
+        if let Some(url) = self.pending_launch_url.as_ref() {
+            return Some(
+                widget::dialog()
+                    .title(fl!("launch-url-confirm-title"))
+                    .body(fl!("launch-url-confirm-body", url = url.as_str()))
+                    .primary_action(
+                        widget::button::suggested(fl!("launch-url-open"))
+                            .on_press(Message::LaunchUrlConfirm),
+                    )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel")).on_press(Message::LaunchUrlCancel),
+                    )
+                    .into(),
+            );
+        }
+
         let conflict = self.shortcut_conflict.as_ref()?;
         let binding = shortcuts::binding_display(&conflict.binding);
         let existing = shortcuts::action_label(conflict.existing_action);
@@ -3658,6 +3696,37 @@ impl Application for App {
             },
         ])
     }
+}
+
+/// Returns true when `url` uses a scheme that is safe to hand to the
+/// platform's URL handler without an extra confirmation step. Anything else
+/// (ssh://, git://, file:, custom desktop-registered schemes, etc.) is routed
+/// through a confirmation dialog so the user sees the full URI before
+/// `open::that_detached` is invoked.
+fn launch_url_scheme_is_safe(url: &str) -> bool {
+    let Some((scheme, _)) = url.split_once(':') else {
+        return false;
+    };
+    // Scheme syntax per RFC 3986: ALPHA *(ALPHA / DIGIT / "+" / "-" / ".")
+    let mut chars = scheme.chars();
+    let valid_scheme = chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'));
+    if !valid_scheme {
+        return false;
+    }
+    matches!(
+        scheme.to_ascii_lowercase().as_str(),
+        "http"
+            | "https"
+            | "mailto"
+            | "ftp"
+            | "ftps"
+            | "gemini"
+            | "gopher"
+            | "ipfs"
+            | "ipns"
+            | "news"
+    )
 }
 
 #[cfg(feature = "wayland")]

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -51,6 +51,11 @@ use crate::{
 
 const AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Pointer movement in pixels above which a left-press release is treated as a
+/// drag rather than a click. Used to suppress hyperlink activation when the
+/// user is selecting text rather than clicking a link.
+const LINK_CLICK_DRAG_THRESHOLD: f32 = 4.0;
+
 /// Drives repeated drag updates while the pointer is outside the widget.
 struct DragAutoscroll {
     active: bool,
@@ -1247,6 +1252,7 @@ where
                                     last_edge_overshoot: 0.0,
                                     last_point: location,
                                     last_side: side,
+                                    press_point: p,
                                 });
                             } else if scrollbar_rect.contains(Point::new(x, y)) {
                                 if let Some(start_scroll) = terminal.scrollbar() {
@@ -1318,12 +1324,12 @@ where
             }
             Event::Mouse(MouseEvent::ButtonReleased(Button::Left)) => {
                 state.autoscroll.stop();
-                if let Some(dragging) = state.dragging.take()
-                    && let Dragging::Buffer {
-                        last_point,
-                        last_side,
-                        ..
-                    } = dragging
+                let buffer_press_point = if let Some(Dragging::Buffer {
+                    last_point,
+                    last_side,
+                    press_point,
+                    ..
+                }) = state.dragging.take()
                 {
                     {
                         let mut term = terminal.term.lock();
@@ -1332,7 +1338,10 @@ where
                         }
                     }
                     terminal.needs_update = true;
-                }
+                    Some(press_point)
+                } else {
+                    None
+                };
                 if let Some(p) = cursor_position.position_in(layout.bounds()) {
                     let x = p.x - self.padding.left;
                     let y = p.y - self.padding.top;
@@ -1342,7 +1351,12 @@ where
 
                     let location = terminal
                         .viewport_to_point(TermPoint::new(row as usize, TermColumn(col as usize)));
-                    if state.modifiers.control()
+                    let was_click = buffer_press_point.is_none_or(|press_point| {
+                        (press_point.x - p.x).abs() < LINK_CLICK_DRAG_THRESHOLD
+                            && (press_point.y - p.y).abs() < LINK_CLICK_DRAG_THRESHOLD
+                    });
+                    if was_click
+                        && state.modifiers.control()
                         && let Some(on_open_hyperlink) = &self.on_open_hyperlink
                         && let Some(hyperlink) = get_hyperlink(&terminal, location)
                     {
@@ -1700,6 +1714,7 @@ enum Dragging {
         last_edge_overshoot: f32,
         last_point: TermPoint,
         last_side: TermSide,
+        press_point: Point,
     },
     Scrollbar {
         start_y: f32,
@@ -1808,6 +1823,7 @@ fn update_buffer_drag(
         last_edge_overshoot,
         last_point,
         last_side,
+        press_point: _,
     } = dragging
     else {
         return false;


### PR DESCRIPTION
Store press_point in Dragging::Buffer; suppress on_open_hyperlink if cursor moved more than 4px between press and release. Fixes #516.

Add launch_url_scheme_is_safe() with RFC 3986 scheme validation and an allowlist. Unusual schemes (ssh://, git://, file:, etc.) show a confirmation dialog with the full URI. 

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


Since I am an Application Security Engineer I wanted to do a security review on the terminal I noticed that there was the possibility for untrusted input to be executed from URI in the term. I looked at issues to see if someone already noticed it and saw #516. This fixes that and adds the security fix. 

Summary of changes: 
1. URLs no longer open when the user ctrl+drags to select text over a link
1. Safe schemes (http, https, mailto, ftp, gemini, etc.) open as before. Unusual schemes (ssh://, git://, file:, etc.) show a confirmation dialog with the full URI before anything is launched


<img width="1011" height="771" alt="Screenshot_2026-05-14_22-13-57" src="https://github.com/user-attachments/assets/bb0a83a6-d018-4417-86d0-2fa142c024ba" />

Detail of Changes:

1. Drag-select suppression (resolves #516)

ButtonReleased consumed state.dragging with .take() before checking whether to fire on_open_hyperlink, discarding the information that a drag was in progress. So a ctrl+drag+release over a URL was indistinguishable from a ctrl+click.

The fix stores the raw pixel press position in Dragging::Buffer as press_point: Point and compares it against the release position. If the cursor moved more than LINK_CLICK_DRAG_THRESHOLD (4px) on either axis, the release is treated as a drag and the hyperlink handler is suppressed.

1. Scheme confirmation dialog

Message::LaunchUrl passed URIs directly to open::that_detached with no scheme validation. The URL regex matches ssh://, git://, and file: in addition to http(s). Any process writing to the PTY can paint one of these into the buffer. ssh:// URIs can trigger ProxyCommand or LocalCommand from ~/.ssh/config; file: can target a .desktop file. Combined with the drag-select bug above, this could fire without deliberate user intent.

The new launch_url_scheme_is_safe helper validates scheme syntax per RFC 3986 and checks against an allowlist. Safe schemes open immediately. Anything else stores the URL in pending_launch_url and the dialog() method renders a COSMIC confirmation dialog showing the full URI, with Open and Cancel actions. Escape also clears a pending URL, consistent with other dialogs in the app.