### PR TITLE
feat: add clear buffer action

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -117,6 +117,7 @@ copy = Copy
 paste = Paste
 select-all = Select all
 find = Find
+clear-buffer = Clear buffer
 clear-scrollback = Clear scrollback
 
 ## Open

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,13 @@
 // Copyright 2023 System76 <info@system76.com>
 // SPDX-License-Identifier: GPL-3.0-only
 
-use alacritty_terminal::{event::Event as TermEvent, term, term::color::Colors as TermColors, tty};
+use alacritty_terminal::{
+    event::Event as TermEvent,
+    grid::{Dimensions, GridCell},
+    index::Line,
+    term::{self, color::Colors as TermColors},
+    tty,
+};
 use cosmic::iced::clipboard::dnd::DndAction;
 use cosmic::iced::core::keyboard::key::Named;
 use cosmic::widget::menu::action::MenuAction;
@@ -238,6 +244,7 @@ pub struct Flags {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Action {
     About,
+    ClearBuffer,
     ClearScrollback,
     ColorSchemes(ColorSchemeKind),
     Copy,
@@ -289,6 +296,7 @@ impl Action {
     fn message(&self, entity_opt: Option<segmented_button::Entity>) -> Message {
         match self {
             Self::About => Message::ToggleContextPage(ContextPage::About),
+            Self::ClearBuffer => Message::ClearBuffer(entity_opt),
             Self::ClearScrollback => Message::ClearScrollback(entity_opt),
             Self::ColorSchemes(color_scheme_kind) => {
                 Message::ToggleContextPage(ContextPage::ColorSchemes(*color_scheme_kind))
@@ -352,6 +360,7 @@ impl MenuAction for Action {
 #[derive(Clone, Debug)]
 pub enum Message {
     AppTheme(AppTheme),
+    ClearBuffer(Option<segmented_button::Entity>),
     ClearScrollback(Option<segmented_button::Entity>),
     ColorSchemeCollapse,
     ColorSchemeDelete(ColorSchemeKind, ColorSchemeId),
@@ -1959,6 +1968,38 @@ impl Application for App {
             Message::AppTheme(app_theme) => {
                 config_set!(app_theme, app_theme);
                 return self.update_config();
+            }
+            Message::ClearBuffer(entity_opt) => {
+                if let Some(tab_model) = self.pane_model.active() {
+                    let entity = entity_opt.unwrap_or_else(|| tab_model.active());
+                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                        let mut terminal = terminal.lock().unwrap();
+                        let mut term = terminal.term.lock();
+                        let grid = term.grid_mut();
+                        let point = grid.cursor.point;
+                        let mut line = point.line;
+                        // Include any wrapped lines above the cursor.
+                        while line > grid.topmost_line()
+                            && grid[line - Line(1)]
+                                .last()
+                                .is_some_and(|c| c.flags().contains(term::cell::Flags::WRAPLINE))
+                        {
+                            line -= 1;
+                        }
+                        let saved_rows: Vec<_> = (line.0..=grid.cursor.point.line.0)
+                            .map(|i| grid[Line(i)].clone())
+                            .collect();
+                        grid.reset();
+                        let new_line = saved_rows.len() - 1;
+                        for (i, row) in saved_rows.into_iter().enumerate() {
+                            grid[Line(i as i32)] = row;
+                        }
+                        grid.cursor.point.line = Line(new_line as i32);
+                        grid.cursor.point.column = point.column;
+                        drop(term);
+                        terminal.needs_update = true;
+                    }
+                }
             }
             Message::ClearScrollback(entity_opt) => {
                 if let Some(tab_model) = self.pane_model.active() {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -81,6 +81,7 @@ pub fn context_menu<'a>(
         Element::from(menu_item(fl!("paste"), Action::Paste)),
         Element::from(menu_item(fl!("select-all"), Action::SelectAll)),
         Element::from(divider::horizontal::light()),
+        Element::from(menu_item(fl!("clear-buffer"), Action::ClearBuffer)),
         Element::from(menu_item(fl!("clear-scrollback"), Action::ClearScrollback)),
         Element::from(divider::horizontal::light()),
         Element::from(menu_item(
@@ -236,6 +237,7 @@ pub fn menu_bar<'a>(
                         MenuItem::Button(fl!("paste"), None, Action::Paste),
                         MenuItem::Button(fl!("select-all"), None, Action::SelectAll),
                         MenuItem::Divider,
+                        MenuItem::Button(fl!("clear-buffer"), None, Action::ClearBuffer),
                         MenuItem::Button(fl!("clear-scrollback"), None, Action::ClearScrollback),
                         MenuItem::Divider,
                         MenuItem::Button(fl!("find"), None, Action::Find),

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -57,6 +57,7 @@ impl Binding {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum KeyBindAction {
     Disable,
+    ClearBuffer,
     ClearScrollback,
     Copy,
     CopyOrSigint,
@@ -99,6 +100,7 @@ impl KeyBindAction {
     fn to_action(self) -> Option<Action> {
         match self {
             Self::Disable => None,
+            Self::ClearBuffer => Some(Action::ClearBuffer),
             Self::ClearScrollback => Some(Action::ClearScrollback),
             Self::Copy => Some(Action::Copy),
             Self::CopyOrSigint => Some(Action::CopyOrSigint),
@@ -259,6 +261,7 @@ impl ShortcutsConfig {
 pub fn action_label(action: KeyBindAction) -> String {
     match action {
         KeyBindAction::Disable => fl!("disable"),
+        KeyBindAction::ClearBuffer => fl!("clear-buffer"),
         KeyBindAction::ClearScrollback => fl!("clear-scrollback"),
         KeyBindAction::Copy => fl!("copy"),
         KeyBindAction::CopyOrSigint => fl!("copy-or-sigint"),
@@ -362,7 +365,7 @@ pub fn shortcut_groups() -> Vec<ShortcutGroup> {
             KeyBindAction::ZoomReset,
         ],
     });
-    let mut other_actions = vec![KeyBindAction::ClearScrollback];
+    let mut other_actions = vec![KeyBindAction::ClearBuffer, KeyBindAction::ClearScrollback];
     #[cfg(feature = "password_manager")]
     other_actions.push(KeyBindAction::PasswordManager);
     groups.push(ShortcutGroup {
@@ -497,6 +500,8 @@ fn fallback_shortcuts() -> Shortcuts {
     bind!([Ctrl, Shift], "ArrowRight", PaneFocusRight);
     bind!([Ctrl, Shift], "L", PaneFocusRight);
 
+    // CTRL+Alt+K clears the screen and entire buffer.
+    bind!([Ctrl, Alt], "K", ClearBuffer);
     // CTRL+Alt+L clears the scrollback.
     bind!([Ctrl, Alt], "L", ClearScrollback);
 


### PR DESCRIPTION
Adds a new action that clears both the visible screen and scrollback buffer while preserving any wrapped lines above the cursor. Default key-binding: Ctrl+Alt+K.

Closes #621 

I used AI to guide the walk‑back logic and research `WRAPLINE` flag placement. All final code, design decisions, and testing are mine.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

