### PR TITLE
Revert "bound the event channel to prevent unbounded RSS growth"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -438,7 +438,7 @@ pub enum Message {
     TabNext,
     TabPrev,
     TermEvent(pane_grid::Pane, segmented_button::Entity, TermEvent),
-    TermEventTx(mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>),
+    TermEventTx(mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>),
     ToggleFullscreen,
     ToggleContextPage(ContextPage),
     UpdateDefaultProfile((bool, ProfileId)),
@@ -502,7 +502,8 @@ pub struct App {
     find: bool,
     find_search_id: widget::Id,
     find_search_value: String,
-    term_event_tx_opt: Option<mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
+    term_event_tx_opt:
+        Option<mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>>,
     startup_options: Option<tty::Options>,
     term_config: term::Config,
     color_scheme_errors: Vec<String>,
@@ -3622,11 +3623,7 @@ impl Application for App {
                 stream::channel(
                     100,
                     |mut output: iced::futures::channel::mpsc::Sender<Message>| async move {
-                        // Bounded: when the GUI can't drain fast enough, alacritty's PTY reader
-                        // blocks on send → kernel pipe fills → producing program is throttled by
-                        // the OS. Capacity 1024 caps the queue depth; per-event memory depends on
-                        // payload (Wakeup is ~100 B; Title/PtyWrite carry owned Strings).
-                        let (event_tx, mut event_rx) = mpsc::channel(1024);
+                        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
                         output.send(Message::TermEventTx(event_tx)).await.unwrap();
 
                         while let Some((pane, entity, event)) = event_rx.recv().await {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -99,16 +99,13 @@ impl From<Size> for WindowSize {
 pub struct EventProxy(
     pane_grid::Pane,
     segmented_button::Entity,
-    mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, Event)>,
+    mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, Event)>,
 );
 
 impl EventListener for EventProxy {
     fn send_event(&self, event: Event) {
-        // Bounded channel; blocking_send propagates backpressure to alacritty's
-        // PTY reader instead of letting events accumulate. Called from alacritty's
-        // std::thread PTY reader (not a tokio worker), so blocking is safe and
-        // blocking_send won't panic.
-        let _ = self.2.blocking_send((self.0, self.1, event));
+        //TODO: handle error
+        let _ = self.2.send((self.0, self.1, event));
     }
 }
 
@@ -273,7 +270,7 @@ impl Terminal {
     pub fn new(
         pane: pane_grid::Pane,
         entity: segmented_button::Entity,
-        event_tx: mpsc::Sender<(pane_grid::Pane, segmented_button::Entity, Event)>,
+        event_tx: mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, Event)>,
         config: Config,
         options: Options,
         app_config: &AppConfig,


### PR DESCRIPTION
Reverts pop-os/cosmic-term#806

Alacritty-term's spawned event loop holds a lease to `Terminal::term`'s mutex until it is finished sending events back to the app. This causes a deadlock at [src/terminal.rs:760 in Terminal::update](https://github.com/pop-os/cosmic-term/blob/master/src/terminal.rs#L760) when the channel is full. For now, it would be best to revert until we refactor this. We may want to avoid sharing a mutex with the event loop.