### PR TITLE
feat: option to open new windows in the current directory

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -63,8 +63,8 @@ focus-follow-mouse = Typing focus follows mouse
 advanced = Advanced
 show-headerbar = Show header
 show-header-description = Reveal the header from the right-click menu
-tab-new-inherit-working-directory = New tabs use current directory
-tab-new-inherit-working-directory-description = Open new tabs in the active tab's working directory
+tab-new-inherit-working-directory = New tabs and windows use current directory
+tab-new-inherit-working-directory-description = Open new tabs and windows in the active tab's working directory
 
 ### Keyboard shortcuts
 add-another-keybinding = Add another keybinding

--- a/src/main.rs
+++ b/src/main.rs
@@ -3225,12 +3225,21 @@ impl Application for App {
                 }
             }
             Message::WindowNew => match env::current_exe() {
-                Ok(exe) => match process::Command::new(&exe).spawn() {
-                    Ok(_child) => {}
-                    Err(err) => {
-                        log::error!("failed to execute {:?}: {}", exe, err);
+                Ok(exe) => {
+                    let mut command = process::Command::new(&exe);
+                    if self.config.tab_new_inherit_working_directory
+                        && let Some(dir) = self.active_terminal_working_directory()
+                    {
+                        command.arg("--working-directory");
+                        command.arg(dir);
                     }
-                },
+                    match command.spawn() {
+                        Ok(_child) => {}
+                        Err(err) => {
+                            log::error!("failed to execute {:?}: {}", exe, err);
+                        }
+                    }
+                }
                 Err(err) => {
                     log::error!("failed to get current executable path: {}", err);
                 }


### PR DESCRIPTION
This reuses the option for "New tab uses the current directory" and does the same for new windows too. So if you open a new window using the menu or `ctrl+shift+n` it opens it in the current directory.

<img width="608" height="1107" alt="image" src="https://github.com/user-attachments/assets/36288159-fa42-4430-a152-3ec286f04ca2" />

This probably needs OK from UX.

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

