### PR TITLE
Fix scrolling in lazygit, less, htop

### DIFF
--- a/src/mouse_reporter.rs
+++ b/src/mouse_reporter.rs
@@ -3,10 +3,6 @@ use cosmic::{
     iced::{Event, keyboard::Modifiers, mouse::Button},
 };
 
-use crate::terminal::Terminal;
-
-const SCROLL_SPEED: u32 = 3;
-
 #[derive(Default)]
 pub struct MouseReporter {
     last_movment_x: Option<u32>,
@@ -17,6 +13,30 @@ pub struct MouseReporter {
 }
 
 impl MouseReporter {
+    pub fn accumulate_scroll(
+        &mut self,
+        delta: ScrollDelta,
+        cell_width: f32,
+        cell_height: f32,
+    ) -> (i32, i32) {
+        match delta {
+            ScrollDelta::Lines { x, y } => {
+                self.accumulated_scroll_x += x;
+                self.accumulated_scroll_y += y;
+            }
+            ScrollDelta::Pixels { x, y } => {
+                self.accumulated_scroll_x += x / cell_width;
+                self.accumulated_scroll_y += y / cell_height;
+            }
+        }
+
+        let lines_x = self.accumulated_scroll_x as i32;
+        let lines_y = self.accumulated_scroll_y as i32;
+        self.accumulated_scroll_x -= lines_x as f32;
+        self.accumulated_scroll_y -= lines_y as f32;
+        (lines_x, lines_y)
+    }
+
     fn button_number(button: Button) -> Option<u8> {
         match button {
             Button::Left => Some(0),
@@ -178,24 +198,7 @@ impl MouseReporter {
         x: u32,
         y: u32,
     ) -> impl Iterator<Item = Vec<u8>> {
-        let (lines_x, lines_y) = match delta {
-            ScrollDelta::Lines { x, y } => (x as i32, y as i32),
-            ScrollDelta::Pixels { x, y } => {
-                //Accumulate change
-                self.accumulated_scroll_x += x / term_cell_width;
-                self.accumulated_scroll_y += y / term_cell_height;
-
-                //Resolve lines crossed
-                let lines_x = self.accumulated_scroll_x as i32;
-                let lines_y = self.accumulated_scroll_y as i32;
-
-                //Subtract accounted lines from accumulators
-                self.accumulated_scroll_x -= lines_x as f32;
-                self.accumulated_scroll_y -= lines_y as f32;
-
-                (lines_x, lines_y)
-            }
-        };
+        let (lines_x, lines_y) = self.accumulate_scroll(delta, term_cell_width, term_cell_height);
 
         //Resolve modifier flags
         let mut modifier_flags = 0;
@@ -234,27 +237,5 @@ impl MouseReporter {
                 let term_code = format!("\x1b[<{};{};{}M", button_no, x + 1, y + 1);
                 term_code.as_bytes().to_vec()
             })
-    }
-
-    //Emulate mouse wheel scroll with up/down arrows. Using mouse spec uses
-    //scroll-back and scroll-forw actions, which moves whole windows like page up/page down.
-    pub fn report_mouse_wheel_as_arrows(
-        terminal: &Terminal,
-        term_cell_width: f32,
-        term_cell_height: f32,
-        delta: ScrollDelta,
-    ) {
-        let (_delta_x, delta_y) = match delta {
-            ScrollDelta::Lines { x, y } => (x, y),
-            ScrollDelta::Pixels { x, y } => (x / term_cell_width, y / term_cell_height),
-        };
-        //Send delta_y * SCROLL_SPEED number of Up/Down arrows
-        for _ in 0..(delta_y.abs() as u32 * SCROLL_SPEED) {
-            if delta_y > 0.0 {
-                terminal.input_no_scroll(b"\x1B[A".as_slice())
-            } else if delta_y < 0.0 {
-                terminal.input_no_scroll(b"\x1B[B".as_slice())
-            }
-        }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1025,10 +1025,9 @@ impl Terminal {
         x: u32,
         y: u32,
     ) {
-        let term_lock = self.term.lock();
-        let mode = term_lock.mode();
+        let is_sgr = self.term.lock().mode().contains(TermMode::SGR_MOUSE);
 
-        if mode.contains(TermMode::SGR_MOUSE) {
+        if is_sgr {
             let codes = self.mouse_reporter.sgr_mouse_wheel_scroll(
                 self.size().cell_width,
                 self.size().cell_height,
@@ -1042,12 +1041,23 @@ impl Terminal {
                 self.notifier.notify(code);
             }
         } else {
-            MouseReporter::report_mouse_wheel_as_arrows(
-                self,
-                self.size().cell_width,
-                self.size().cell_height,
-                delta,
-            );
+            self.scroll_as_arrows(delta);
+        }
+    }
+
+    pub fn scroll_as_arrows(&mut self, delta: ScrollDelta) {
+        let cell_width = self.size().cell_width;
+        let cell_height = self.size().cell_height;
+        let (_, lines_y) = self
+            .mouse_reporter
+            .accumulate_scroll(delta, cell_width, cell_height);
+        const SCROLL_SPEED: u32 = 3;
+        for _ in 0..(lines_y.unsigned_abs() * SCROLL_SPEED) {
+            if lines_y > 0 {
+                self.input_no_scroll(b"\x1B[A".as_slice())
+            } else if lines_y < 0 {
+                self.input_no_scroll(b"\x1B[B".as_slice())
+            }
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1051,12 +1051,18 @@ impl Terminal {
         let (_, lines_y) = self
             .mouse_reporter
             .accumulate_scroll(delta, cell_width, cell_height);
+        let is_app_cursor = self.term.lock().mode().contains(TermMode::APP_CURSOR);
+        let (up, down) = if is_app_cursor {
+            (&b"\x1BOA"[..], &b"\x1BOB"[..])
+        } else {
+            (&b"\x1B[A"[..], &b"\x1B[B"[..])
+        };
         const SCROLL_SPEED: u32 = 3;
         for _ in 0..(lines_y.unsigned_abs() * SCROLL_SPEED) {
             if lines_y > 0 {
-                self.input_no_scroll(b"\x1B[A".as_slice())
+                self.input_no_scroll(up)
             } else if lines_y < 0 {
-                self.input_no_scroll(b"\x1B[B".as_slice())
+                self.input_no_scroll(down)
             }
         }
     }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -45,10 +45,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    Action, Terminal, TerminalScroll, menu::MenuState, mouse_reporter::MouseReporter,
-    terminal::Metadata,
-};
+use crate::{Action, Terminal, TerminalScroll, menu::MenuState, terminal::Metadata};
 
 const AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -1551,12 +1548,7 @@ where
                         let row = y / terminal.size().cell_height;
                         terminal.scroll_mouse(*delta, &state.modifiers, col as u32, row as u32);
                     } else if terminal.term.lock().mode().contains(TermMode::ALT_SCREEN) {
-                        MouseReporter::report_mouse_wheel_as_arrows(
-                            &terminal,
-                            terminal.size().cell_width,
-                            terminal.size().cell_height,
-                            *delta,
-                        );
+                        terminal.scroll_as_arrows(*delta);
                         shell.capture_event();
                     } else {
                         match delta {


### PR DESCRIPTION
Fixes scrolling in lazygit, less, htop, man...

If you open lazygit and try to scroll the code changes using a high res mouse (e.g. MX Master 3S). It does not scroll unless you scroll super fast. It's because the scroll even comes in and since the amount is less than a line, it gets rounded down to 0, instead getting accumulated.

The issue with `less` was that we always were sending normal-mode sequence `b"\x1B[A"`, but `less` sets application cursor mode and expects `b"\x1bOA"`. 


I had to move `report_mouse_wheel_as_arrows` to the `terminal.rs` to keep Rust happy since we need mutable access to the terminal and the terminal's mouse_reporter.

____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

