### PR TITLE
fix: avoid unnecessary shape-until-cursor at start-up

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -21,8 +21,7 @@ use cosmic::{
     widget::{pane_grid, segmented_button},
 };
 use cosmic_text::{
-    Attrs, AttrsList, Buffer, BufferLine, CacheKeyFlags, Family, LineEnding, Metrics, Shaping,
-    Weight, Wrap,
+    Attrs, AttrsList, Buffer, BufferLine, CacheKeyFlags, Family, LineEnding, Shaping, Weight, Wrap,
 };
 use indexmap::IndexSet;
 use std::{
@@ -284,7 +283,7 @@ impl Terminal {
         let bold_font_weight = app_config.bold_font_weight;
         let use_bright_bold = app_config.use_bright_bold;
 
-        let metrics = Metrics::new(14.0, 21.0);
+        let metrics = app_config.metrics(0);
 
         let default_bg = convert_color(&colors, Color::Named(NamedColor::Background));
         let default_fg = convert_color(&colors, Color::Named(NamedColor::Foreground));
@@ -640,7 +639,7 @@ impl Terminal {
             update_cell_size = true;
         }
 
-        if self.bold_font_weight.0 != config.font_weight {
+        if self.bold_font_weight.0 != config.bold_font_weight {
             self.bold_font_weight = Weight(config.bold_font_weight);
             update_cell_size = true;
         }


### PR DESCRIPTION
Seems like a typo comparing bold font weight to normal font weight was marking `update_cell_size=true` which would cause a call to `shape_until_cursor` on startup.

Before:
<img width="848" height="485" alt="image" src="https://github.com/user-attachments/assets/8fcbffb0-0f87-4840-8d1a-fb83ba64e3f9" />


After:
<img width="771" height="260" alt="image" src="https://github.com/user-attachments/assets/871451b4-8060-45e8-8284-d5a966907add" />

___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

