### PR TITLE
keybindings: Fix terminal undo

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1127,6 +1127,7 @@ where
                 modifiers,
                 key,
                 physical_key,
+                modified_key,
                 ..
             }) if state.is_focused => {
                 for key_bind in self.key_binds.keys() {
@@ -1173,11 +1174,10 @@ where
                         }
                     }
                     (false, true, _, true) => {
-                        //This is normally Ctrl+Minus, but since that
-                        //is taken by zoom, we send that code for
-                        //Ctrl+Underline instead, like xterm and
-                        //gnome-terminal
-                        if *key == Key::Character("_".into()) {
+                        // Ctrl+Shift+<key>: send 0x1F (C-_) on '_', matching xterm/gnome-terminal.
+                        // Use `modified_key` so this works regardless of which physical key
+                        // produces '_' on the user's layout.
+                        if *modified_key == Key::Character("_".into()) {
                             terminal.input_scroll(b"\x1F".as_slice());
                             shell.capture_event();
                         }


### PR DESCRIPTION
Currently the ~normal undo pattern for terminals doesnt work (ctrl-shift--)

I used ai to track the actual issue (and improve comment)

I have tested extensively locally - and it makes cosmic-term work for me!


- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

