### PR TITLE
Avoid re-reading system theme from disk on every menu bar render

### DIFF
--- a/src/menu.rs
+++ b/src/menu.rs
@@ -18,7 +18,7 @@ use cosmic::{
 };
 use std::{collections::HashMap, sync::LazyLock};
 
-use crate::{Action, ColorSchemeId, ColorSchemeKind, Config, Message, fl};
+use crate::{Action, AppTheme, ColorSchemeId, ColorSchemeKind, Config, Message, fl};
 
 static MENU_ID: LazyLock<cosmic::widget::Id> =
     LazyLock::new(|| cosmic::widget::Id::new("responsive-menu"));
@@ -206,6 +206,19 @@ pub fn menu_bar<'a>(
 
     //TODO: what to do if there are no profiles?
 
+    // Determine dark/light scheme from in-memory state. 
+    let color_scheme_kind = match config.app_theme {
+        AppTheme::Dark => ColorSchemeKind::Dark,
+        AppTheme::Light => ColorSchemeKind::Light,
+        AppTheme::System => {
+            if core.system_theme().theme_type.is_dark() {
+                ColorSchemeKind::Dark
+            } else {
+                ColorSchemeKind::Light
+            }
+        }
+    };
+
     responsive_menu_bar()
         .item_height(ItemHeight::Dynamic(40))
         .item_width(ItemWidth::Uniform(320))
@@ -267,7 +280,7 @@ pub fn menu_bar<'a>(
                         MenuItem::Button(
                             fl!("menu-color-schemes"),
                             None,
-                            Action::ColorSchemes(config.color_scheme_kind()),
+                            Action::ColorSchemes(color_scheme_kind),
                         ),
                         MenuItem::Button(
                             fl!("menu-keyboard-shortcuts"),


### PR DESCRIPTION
menu_bar() would read the dark/light scheme preference from disk on every view rebuild.  This uses the cached core.system_theme instead.

I used AI for validating and reviewing the debug steps and final code.

Fixes #843

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

