### PR TITLE
fix: report effective OSC 11 background

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3066,7 +3066,7 @@ impl Application for App {
                             && let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity)
                         {
                             let terminal = terminal.lock().unwrap();
-                            let rgb = terminal.colors()[index].unwrap_or_default();
+                            let rgb = terminal.effective_color(index);
                             let text = f(rgb);
                             terminal.input_no_scroll(text.into_bytes());
                         }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -386,6 +386,19 @@ impl Terminal {
         &self.colors
     }
 
+    pub fn effective_color(&self, index: usize) -> Rgb {
+        if index == NamedColor::Background as usize {
+            self.colors[index].unwrap_or_else(|| {
+                // Allow using an unset background
+                let [r, g, b, _] =
+                    cosmic_text::Color(WINDOW_BG_COLOR.load(Ordering::SeqCst)).as_rgba();
+                Rgb { r, g, b }
+            })
+        } else {
+            self.colors[index].unwrap_or_default()
+        }
+    }
+
     pub fn default_attrs(&self) -> &Attrs<'static> {
         &self.default_attrs
     }


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---
This makes OSC 11 return the same background color that is being rendered, i.e. it accounts for the current `WINDOW_BG_COLOR` that is set by theme.

This is meant as a simple fix for now without trying to unify/refactor the rest of the code, so this duplicates the simple code path and copies the same comment for easier greppability; please let me know if you'd like to see the unification as part of this PR.

Part of #813 

For example, Vim uses it to detect the themes, and so here's an example rendering of Cargo.toml before (notice the bright pink, which shouldn't be a foreground color on a light theme):
<img width="1024" height="768" alt="before" src="https://github.com/user-attachments/assets/76fe2a13-91ae-4def-9f22-0fd669a2da50" />

and after:
<img width="1024" height="768" alt="after" src="https://github.com/user-attachments/assets/c5807941-70cd-4e4b-9c4d-0785a35f5ea0" />

