### PR TITLE
fix: only PaneClicked events change focus

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2582,7 +2582,8 @@ impl Application for App {
             }
             Message::PaneClicked(pane) => {
                 self.pane_model.set_focus(pane);
-                return self.update_title(Some(pane));
+                let title_task = self.update_title(Some(pane));
+                return Task::batch([self.update_focus(), title_task]);
             }
             Message::PaneSplit(axis) => {
                 let result = self.pane_model.panes.split(

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -1377,8 +1377,6 @@ where
                         }
                         shell.capture_event();
                     }
-                } else {
-                    state.is_focused = false;
                 }
             }
             Event::Mouse(MouseEvent::ButtonReleased(Button::Left)) => {


### PR DESCRIPTION
This changes the focus logic so that clicking the title bar(to move the window around) or resize buttons doesn't automatically unfocus the current pane. All the pane focus logic goes through PaneClicked=>update_focus.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

