### PR TITLE
feat: add configurable cursor appearance settings

### DIFF
--- a/i18n/af/cosmic_term.ftl
+++ b/i18n/af/cosmic_term.ftl
@@ -45,6 +45,27 @@ make-default = Stel as verstek
 hold = Behou
 remain-open = Hou die venster oop nadat die onderliggende proses voltooi is.
 opacity = Agtergronddekking
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 advanced-font-settings = Gevorderde lettertipe-instellings
 default-font-size = Lettergrootte
 advanced = Gevorder

--- a/i18n/ar/cosmic_term.ftl
+++ b/i18n/ar/cosmic_term.ftl
@@ -49,6 +49,27 @@ syntax-dark = مخطط الألوان الداكن
 syntax-light = مخطط الألوان الفاتح
 default-zoom-step = خطوات التكبير
 opacity = شفافية الخلفية
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/be/cosmic_term.ftl
+++ b/i18n/be/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Цёмны сінтаксіс
 syntax-light = Светлы сінтаксіс
 default-zoom-step = Крок маштабавання
 opacity = Непразрыстасць фону
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/bg/cosmic_term.ftl
+++ b/i18n/bg/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Тъмна цветова схема
 syntax-light = Светла цветова схема
 default-zoom-step = Стандартен мащаб
 opacity = Прозрачност на фона
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/cs/cosmic_term.ftl
+++ b/i18n/cs/cosmic_term.ftl
@@ -33,6 +33,27 @@ syntax-dark = Barevné schéma tmavé
 syntax-light = Barevné schéma světlé
 default-zoom-step = Kroky přiblížení
 opacity = Průhlednost pozadí
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Písmo
 advanced-font-settings = Pokročilá nastavení písma
 default-font = Písmo

--- a/i18n/de/cosmic_term.ftl
+++ b/i18n/de/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Dunkles Farbschema
 syntax-light = Helles Farbschema
 default-zoom-step = Zoomstufen
 opacity = Hintergrunddeckkraft
+cursor = Cursor
+cursor-color = Cursorfarbe
+cursor-color-scheme = Farbschema verwenden
+cursor-color-custom = Benutzerdefinierte Farbe
+cursor-color-custom-description = Hex-Farbe (z. B. #ff0000)
+cursor-style = Cursorstil
+cursor-style-follow-terminal = Terminal folgen
+cursor-style-block = Block
+cursor-style-beam = Strich
+cursor-style-underline = Unterstrichen
+cursor-style-hollow-block = Hohler Block
+cursor-unfocused-style = Cursorstil ohne Fokus
+cursor-blink = Cursor blinkt
+cursor-blink-respect-terminal = Terminal folgen
+cursor-blink-always = Immer blinken
+cursor-blink-never = Nie blinken
+cursor-blink-interval = Blinkintervall
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } Millisekunde
+   *[other] { $ms } Millisekunden
+}
 
 ### Schriftart
 

--- a/i18n/el/cosmic_term.ftl
+++ b/i18n/el/cosmic_term.ftl
@@ -48,6 +48,27 @@ syntax-dark = Σκουρόχρωμος χρωματικός συνδυασμός
 syntax-light = Ανοιχτόχρωμος χρωματικός συνδυασμός
 default-zoom-step = Βήματα ζουμ
 opacity = Αδιαφάνεια φόντου
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/en-GB/cosmic_term.ftl
+++ b/i18n/en-GB/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Colour scheme dark
 syntax-light = Colour scheme light
 default-zoom-step = Zoom steps
 opacity = Background opacity
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -43,6 +43,27 @@ syntax-dark = Color scheme dark
 syntax-light = Color scheme light
 default-zoom-step = Zoom steps
 opacity = Background opacity
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 font = Font

--- a/i18n/es-419/cosmic_term.ftl
+++ b/i18n/es-419/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Esquema de color oscuro
 syntax-light = Esquema de color claro
 default-zoom-step = Granularidad de ampliación
 opacity = Opacidad de fondo
+cursor = Cursor
+cursor-color = Color del cursor
+cursor-color-scheme = Usar esquema de color
+cursor-color-custom = Color personalizado
+cursor-color-custom-description = Color hexadecimal (p. ej. #ff0000)
+cursor-style = Estilo del cursor
+cursor-style-follow-terminal = Seguir la terminal
+cursor-style-block = Bloque
+cursor-style-beam = Barra
+cursor-style-underline = Subrayado
+cursor-style-hollow-block = Bloque hueco
+cursor-unfocused-style = Estilo del cursor sin foco
+cursor-blink = Parpadeo del cursor
+cursor-blink-respect-terminal = Seguir la terminal
+cursor-blink-always = Parpadear siempre
+cursor-blink-never = No parpadear nunca
+cursor-blink-interval = Intervalo de parpadeo
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milisegundo
+   *[other] { $ms } milisegundos
+}
 
 ### Font
 

--- a/i18n/es-ES/cosmic_term.ftl
+++ b/i18n/es-ES/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Esquema de color oscuro
 syntax-light = Esquema de color claro
 default-zoom-step = Escalas de zoom
 opacity = Opacidad de fondo
+cursor = Cursor
+cursor-color = Color del cursor
+cursor-color-scheme = Usar esquema de color
+cursor-color-custom = Color personalizado
+cursor-color-custom-description = Color hexadecimal (p. ej. #ff0000)
+cursor-style = Estilo del cursor
+cursor-style-follow-terminal = Seguir el terminal
+cursor-style-block = Bloque
+cursor-style-beam = Barra
+cursor-style-underline = Subrayado
+cursor-style-hollow-block = Bloque hueco
+cursor-unfocused-style = Estilo del cursor sin foco
+cursor-blink = Parpadeo del cursor
+cursor-blink-respect-terminal = Seguir el terminal
+cursor-blink-always = Parpadear siempre
+cursor-blink-never = No parpadear nunca
+cursor-blink-interval = Intervalo de parpadeo
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milisegundo
+   *[other] { $ms } milisegundos
+}
 
 ### Font
 

--- a/i18n/et/cosmic_term.ftl
+++ b/i18n/et/cosmic_term.ftl
@@ -25,6 +25,27 @@ new-profile = Uus profiil
 make-default = Määra vaikimisi väärtuseks
 working-directory = Töökaust
 opacity = Tausta läbipaistmatus
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Kirjatüüp
 advanced-font-settings = Kirjatüübi täiendavad seadistused
 default-font = Kirjatüüp

--- a/i18n/fi/cosmic_term.ftl
+++ b/i18n/fi/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Tumma väriteema
 syntax-light = Vaalea väriteema
 default-zoom-step = Zoomauksen askeleet
 opacity = Taustan peittävyys
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/fr/cosmic_term.ftl
+++ b/i18n/fr/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Palette de couleur sombre
 syntax-light = Palette de couleur claire
 default-zoom-step = Niveaux de zoom
 opacity = Opacité de l'arrière-plan
+cursor = Curseur
+cursor-color = Couleur du curseur
+cursor-color-scheme = Utiliser la palette
+cursor-color-custom = Couleur personnalisée
+cursor-color-custom-description = Couleur hexadécimale (ex. #ff0000)
+cursor-style = Style du curseur
+cursor-style-follow-terminal = Suivre le terminal
+cursor-style-block = Bloc
+cursor-style-beam = Barre verticale
+cursor-style-underline = Soulignement
+cursor-style-hollow-block = Bloc creux
+cursor-unfocused-style = Style du curseur non focalisé
+cursor-blink = Clignotement du curseur
+cursor-blink-respect-terminal = Suivre le terminal
+cursor-blink-always = Toujours clignoter
+cursor-blink-never = Ne jamais clignoter
+cursor-blink-interval = Intervalle de clignotement
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milliseconde
+   *[other] { $ms } millisecondes
+}
 
 ### Font
 

--- a/i18n/ga/cosmic_term.ftl
+++ b/i18n/ga/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Scéim dathanna dorcha
 syntax-light = Scéim dathanna solas
 default-zoom-step = Céimeanna súmála
 opacity = Teimhneacht cúlra
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/hi/cosmic_term.ftl
+++ b/i18n/hi/cosmic_term.ftl
@@ -42,6 +42,27 @@ syntax-dark = रंग योजना डार्क
 syntax-light = रंग योजना लाइट
 default-zoom-step = ज़ूम चरण
 opacity = पृष्ठभूमि अपारदर्शिता
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/hu/cosmic_term.ftl
+++ b/i18n/hu/cosmic_term.ftl
@@ -49,6 +49,27 @@ syntax-dark = Sötét színséma
 syntax-light = Világos színséma
 default-zoom-step = Nagyítási mérték
 opacity = Háttér átlátszósága
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/id/cosmic_term.ftl
+++ b/i18n/id/cosmic_term.ftl
@@ -29,6 +29,27 @@ light = Terang
 syntax-dark = Skema warna gelap
 default-zoom-step = Langkah pembesar
 opacity = Opasitas latar belakang
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Huruf
 advanced-font-settings = Pengaturan huruf lanjutan
 default-font = Huruf

--- a/i18n/is/cosmic_term.ftl
+++ b/i18n/is/cosmic_term.ftl
@@ -27,6 +27,27 @@ syntax-dark = Dökkt litastef
 syntax-light = Ljóst litastef
 default-zoom-step = Aðdráttarskref
 opacity = Gagnsæi bakgrunns
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Leturgerð
 advanced-font-settings = Ítarlegar leturstillingar
 default-font = Leturgerð

--- a/i18n/it/cosmic_term.ftl
+++ b/i18n/it/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Schema colori scuro
 syntax-light = Schema colori chiaro
 default-zoom-step = Livello zoom
 opacity = Opacità sfondo
+cursor = Cursore
+cursor-color = Colore del cursore
+cursor-color-scheme = Usa schema colori
+cursor-color-custom = Colore personalizzato
+cursor-color-custom-description = Colore esadecimale (es. #ff0000)
+cursor-style = Stile del cursore
+cursor-style-follow-terminal = Segui il terminale
+cursor-style-block = Blocco
+cursor-style-beam = Barra
+cursor-style-underline = Sottolineato
+cursor-style-hollow-block = Blocco vuoto
+cursor-unfocused-style = Stile cursore senza focus
+cursor-blink = Lampeggio cursore
+cursor-blink-respect-terminal = Segui il terminale
+cursor-blink-always = Lampeggia sempre
+cursor-blink-never = Non lampeggiare mai
+cursor-blink-interval = Intervallo di lampeggio
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecondo
+   *[other] { $ms } millisecondi
+}
 
 ### Font
 

--- a/i18n/ja/cosmic_term.ftl
+++ b/i18n/ja/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = 構文強調 ダーク
 syntax-light = 構文強調 ライト
 default-zoom-step = ズームステップ
 opacity = 透明度
+cursor = カーソル
+cursor-color = カーソルの色
+cursor-color-scheme = カラースキームを使用
+cursor-color-custom = カスタム色
+cursor-color-custom-description = 16進色（例: #ff0000）
+cursor-style = カーソルスタイル
+cursor-style-follow-terminal = ターミナルに従う
+cursor-style-block = ブロック
+cursor-style-beam = ビーム
+cursor-style-underline = 下線
+cursor-style-hollow-block = 中空ブロック
+cursor-unfocused-style = 非フォーカス時のカーソルスタイル
+cursor-blink = カーソルの点滅
+cursor-blink-respect-terminal = ターミナルに従う
+cursor-blink-always = 常に点滅
+cursor-blink-never = 点滅しない
+cursor-blink-interval = 点滅間隔
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } ミリ秒
+   *[other] { $ms } ミリ秒
+}
 
 ### Font
 

--- a/i18n/kab/cosmic_term.ftl
+++ b/i18n/kab/cosmic_term.ftl
@@ -66,6 +66,27 @@ hold = Ṭṭef
 syntax-dark = Azenziɣ n yini aɣmayan
 syntax-light = Azenziɣ n yini aceɛlal
 opacity = Tiḍullest n ugilal
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 advanced-font-settings = Iɣewwaṛen inaẓiyen n tsefsit
 default-font-size = Tiddi n tsefsit
 default-font-stretch = Ajbad n tsefsit

--- a/i18n/kk/cosmic_term.ftl
+++ b/i18n/kk/cosmic_term.ftl
@@ -44,6 +44,27 @@ remain-open = Туынды процесс аяқталғаннан кейін а
 syntax-dark = Қараңғы түстер схемасы
 syntax-light = Ашық түстер схемасы
 opacity = Фон мөлдірлігі
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Қаріп
 advanced-font-settings = Қаріптің қосымша баптаулары
 default-font = Қаріп

--- a/i18n/kmr/cosmic_term.ftl
+++ b/i18n/kmr/cosmic_term.ftl
@@ -73,6 +73,27 @@ syntax-dark = Şêwaza rengê tarî
 menu-about = Derbarê termînala COSMIC...
 menu-color-schemes = Şêwazên rengê...
 opacity = Zelaliya paşrûyê
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 zoom-reset = Mezinahiya nivîsê ya berdest
 passwords-title = Borînpeyv
 pane-toggle-maximize = Mezinkirinê biguhêrîne

--- a/i18n/kn/cosmic_term.ftl
+++ b/i18n/kn/cosmic_term.ftl
@@ -42,6 +42,27 @@ syntax-dark = ಬಣ್ಣ ಸ್ಕೀಮ್ ಡಾರ್ಕ್
 syntax-light = ಬಣ್ಣ ಸ್ಕೀಮ್ ಲೈಟ್
 default-zoom-step = ಜೂಮ್ ಹಂತಗಳು
 opacity = ಹಿನ್ನಲೆ ಪಾರದರ್ಶಕತೆ
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/ko/cosmic_term.ftl
+++ b/i18n/ko/cosmic_term.ftl
@@ -38,6 +38,27 @@ remain-open = 자식 프로세스 종료 후 열린 상태를 유지합니다.
 menu-color-schemes = 색 구성표...
 working-directory = 작업 디렉터리
 opacity = 배경 투명도
+cursor = 커서
+cursor-color = 커서 색상
+cursor-color-scheme = 색 구성표 사용
+cursor-color-custom = 사용자 지정 색상
+cursor-color-custom-description = 16진수 색상(예: #ff0000)
+cursor-style = 커서 스타일
+cursor-style-follow-terminal = 터미널 따르기
+cursor-style-block = 블록
+cursor-style-beam = 막대
+cursor-style-underline = 밑줄
+cursor-style-hollow-block = 빈 블록
+cursor-unfocused-style = 포커스 없을 때 커서 스타일
+cursor-blink = 커서 깜빡임
+cursor-blink-respect-terminal = 터미널 따르기
+cursor-blink-always = 항상 깜빡임
+cursor-blink-never = 깜빡이지 않음
+cursor-blink-interval = 깜빡임 간격
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } 밀리초
+   *[other] { $ms } 밀리초
+}
 tab-title = 탭 제목
 zoom-reset = 기본 텍스트 크기
 passwords-title = 암호

--- a/i18n/lt/cosmic_term.ftl
+++ b/i18n/lt/cosmic_term.ftl
@@ -25,6 +25,27 @@ theme = Stilius
 match-desktop = Pagal darbalaukio temą
 default-zoom-step = Artinimo žingsniai
 opacity = Fono skaidrumas
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Šriftas
 advanced-font-settings = Išplėstiniai šrifto nustatymai
 default-font = Šriftas

--- a/i18n/nb-NO/cosmic_term.ftl
+++ b/i18n/nb-NO/cosmic_term.ftl
@@ -26,6 +26,27 @@ make-default = Gjør til standard
 working-directory = Arbeidsmappe
 repository = Kodelager
 opacity = Bakgrunnsgjennomsiktighet
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = Skrifttype
 advanced-font-settings = Avanserte skriftinnstillinger
 default-font = Skrifttype

--- a/i18n/nl/cosmic_term.ftl
+++ b/i18n/nl/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Donker kleurenpalet
 syntax-light = Licht kleurenpalet
 default-zoom-step = Zoomstappen
 opacity = Achtergronddoorzichtigheid
+cursor = Cursor
+cursor-color = Cursorkleur
+cursor-color-scheme = Kleurenschema gebruiken
+cursor-color-custom = Aangepaste kleur
+cursor-color-custom-description = Hex-kleur (bijv. #ff0000)
+cursor-style = Cursorstijl
+cursor-style-follow-terminal = Terminal volgen
+cursor-style-block = Blok
+cursor-style-beam = Balk
+cursor-style-underline = Onderstrepen
+cursor-style-hollow-block = Hol blok
+cursor-unfocused-style = Cursorstijl zonder focus
+cursor-blink = Cursor knippert
+cursor-blink-respect-terminal = Terminal volgen
+cursor-blink-always = Altijd knipperen
+cursor-blink-never = Nooit knipperen
+cursor-blink-interval = Knipperinterval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milliseconde
+   *[other] { $ms } milliseconden
+}
 
 ### Font
 

--- a/i18n/pa/cosmic_term.ftl
+++ b/i18n/pa/cosmic_term.ftl
@@ -49,6 +49,27 @@ hold = ਹੋਲਡ
 syntax-dark = ਰੰਗ ਸਕੀਮ ਗੂੜ੍ਹੀ
 syntax-light = ਰੰਗ ਸਕੀਮ ਫ਼ਿੱਕੀ
 opacity = ਬੈਕਗਰਾਊਂਡ ਧੁੰਦਲਾਪਨ
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 font = ਫ਼ੋਂਟ
 advanced-font-settings = ਤਕਨੀਕੀ ਫ਼ੋਂਟ ਸੈਟਿੰਗਾਂ
 default-font = ਫ਼ੋਂਟ

--- a/i18n/pl/cosmic_term.ftl
+++ b/i18n/pl/cosmic_term.ftl
@@ -49,6 +49,27 @@ syntax-dark = Ciemny schemat kolorów
 syntax-light = Jasny schemat kolorów
 default-zoom-step = Stopniowanie powiększania
 opacity = Przejrzystość Tła
+cursor = Kursor
+cursor-color = Kolor kursora
+cursor-color-scheme = Użyj schematu kolorów
+cursor-color-custom = Niestandardowy kolor
+cursor-color-custom-description = Kolor szesnastkowy (np. #ff0000)
+cursor-style = Styl kursora
+cursor-style-follow-terminal = Zgodnie z terminalem
+cursor-style-block = Blok
+cursor-style-beam = Pasek
+cursor-style-underline = Podkreślenie
+cursor-style-hollow-block = Pusty blok
+cursor-unfocused-style = Styl kursora bez fokusu
+cursor-blink = Miganie kursora
+cursor-blink-respect-terminal = Zgodnie z terminalem
+cursor-blink-always = Zawsze migaj
+cursor-blink-never = Nigdy nie migaj
+cursor-blink-interval = Interwał migania
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milisekunda
+   *[other] { $ms } milisekund
+}
 
 ### Font
 

--- a/i18n/pt-BR/cosmic_term.ftl
+++ b/i18n/pt-BR/cosmic_term.ftl
@@ -49,6 +49,27 @@ syntax-dark = Esquema de cores escuro
 syntax-light = Esquema de cores claro
 default-zoom-step = Incremento de zoom
 opacity = Opacidade do fundo
+cursor = Cursor
+cursor-color = Cor do cursor
+cursor-color-scheme = Usar esquema de cores
+cursor-color-custom = Cor personalizada
+cursor-color-custom-description = Cor hexadecimal (ex. #ff0000)
+cursor-style = Estilo do cursor
+cursor-style-follow-terminal = Seguir o terminal
+cursor-style-block = Bloco
+cursor-style-beam = Barra
+cursor-style-underline = Sublinhado
+cursor-style-hollow-block = Bloco oco
+cursor-unfocused-style = Estilo do cursor sem foco
+cursor-blink = Piscar do cursor
+cursor-blink-respect-terminal = Seguir o terminal
+cursor-blink-always = Sempre piscar
+cursor-blink-never = Nunca piscar
+cursor-blink-interval = Intervalo de piscar
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milissegundo
+   *[other] { $ms } milissegundos
+}
 
 ### Font
 

--- a/i18n/pt/cosmic_term.ftl
+++ b/i18n/pt/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Esquema de cores escuro
 syntax-light = Esquema de cores claro
 default-zoom-step = Etapas de Zoom
 opacity = Opacidade do fundo
+cursor = Cursor
+cursor-color = Cor do cursor
+cursor-color-scheme = Usar esquema de cores
+cursor-color-custom = Cor personalizada
+cursor-color-custom-description = Cor hexadecimal (ex. #ff0000)
+cursor-style = Estilo do cursor
+cursor-style-follow-terminal = Seguir o terminal
+cursor-style-block = Bloco
+cursor-style-beam = Barra
+cursor-style-underline = Sublinhado
+cursor-style-hollow-block = Bloco oco
+cursor-unfocused-style = Estilo do cursor sem foco
+cursor-blink = Piscar do cursor
+cursor-blink-respect-terminal = Seguir o terminal
+cursor-blink-always = Piscar sempre
+cursor-blink-never = Nunca piscar
+cursor-blink-interval = Intervalo de piscar
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } milissegundo
+   *[other] { $ms } milissegundos
+}
 
 ### Font
 

--- a/i18n/ro/cosmic_term.ftl
+++ b/i18n/ro/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Schematizare culoare întunecată
 syntax-light = Schematizare culoare luminoasă
 default-zoom-step = Pași zoom
 opacity = Opacitate fundal
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/ru/cosmic_term.ftl
+++ b/i18n/ru/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Тёмная цветовая схема
 syntax-light = Светлая цветовая схема
 default-zoom-step = Шаг масштабирования
 opacity = Прозрачность фона
+cursor = Курсор
+cursor-color = Цвет курсора
+cursor-color-scheme = Использовать цветовую схему
+cursor-color-custom = Пользовательский цвет
+cursor-color-custom-description = Шестнадцатеричный цвет (напр. #ff0000)
+cursor-style = Стиль курсора
+cursor-style-follow-terminal = Как в терминале
+cursor-style-block = Блок
+cursor-style-beam = Линия
+cursor-style-underline = Подчёркивание
+cursor-style-hollow-block = Полый блок
+cursor-unfocused-style = Стиль курсора без фокуса
+cursor-blink = Мигание курсора
+cursor-blink-respect-terminal = Как в терминале
+cursor-blink-always = Всегда мигать
+cursor-blink-never = Никогда не мигать
+cursor-blink-interval = Интервал мигания
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } миллисекунда
+   *[other] { $ms } миллисекунд
+}
 
 ### Font
 

--- a/i18n/sk/cosmic_term.ftl
+++ b/i18n/sk/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Farebná schéma tmavá
 syntax-light = Farebná schéma svetlá
 default-zoom-step = Kroky priblíženia
 opacity = Priehľadnosť pozadia
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Písmo
 

--- a/i18n/sr-Cyrl/cosmic_term.ftl
+++ b/i18n/sr-Cyrl/cosmic_term.ftl
@@ -42,6 +42,27 @@ syntax-dark = Тамна тема синтаксе
 syntax-light = Светла тема синтаксе
 default-zoom-step = Подразумевани корак увећања
 opacity = Непрозирност позадине
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/sr-Latn/cosmic_term.ftl
+++ b/i18n/sr-Latn/cosmic_term.ftl
@@ -42,6 +42,27 @@ syntax-dark = Tamna tema sintakse
 syntax-light = Svetla tema sintakse
 default-zoom-step = Stepeni uvećanja
 opacity = Neprozirnost pozadine
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/sr/cosmic_term.ftl
+++ b/i18n/sr/cosmic_term.ftl
@@ -33,6 +33,27 @@ menu-color-schemes = Шеме боја...
 working-directory = Радни директоријум
 profiles = Профили
 opacity = Непровидност позадине
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 tab-title = Наслов језичка
 zoom-reset = Подразумевана величина текста
 rename = Преименуј

--- a/i18n/sv-SE/cosmic_term.ftl
+++ b/i18n/sv-SE/cosmic_term.ftl
@@ -47,6 +47,27 @@ syntax-dark = Färgschema mörkt
 syntax-light = Färgschema ljust
 default-zoom-step = Zoom-steg
 opacity = Bakgrundens opacitet
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Teckensnitt
 

--- a/i18n/th/cosmic_term.ftl
+++ b/i18n/th/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = โทนสีมืด
 syntax-light = โทนสีสว่าง
 default-zoom-step = ระยะซูม
 opacity = ความทึบของพื้นหลัง
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/tr/cosmic_term.ftl
+++ b/i18n/tr/cosmic_term.ftl
@@ -42,6 +42,27 @@ syntax-dark = Karanlık renk şeması
 syntax-light = Aydınlık renk şeması
 default-zoom-step = Yakınlaştırma adımları
 opacity = Arkaplan saydamlığı
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/uk/cosmic_term.ftl
+++ b/i18n/uk/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = Темна колірна схема
 syntax-light = Світла колірна схема
 default-zoom-step = Зміна масштабу
 opacity = Непрозорість тла
+cursor = Cursor
+cursor-color = Cursor color
+cursor-color-scheme = Use color scheme
+cursor-color-custom = Custom color
+cursor-color-custom-description = Hex color (e.g. #ff0000)
+cursor-style = Cursor style
+cursor-style-follow-terminal = Follow terminal
+cursor-style-block = Block
+cursor-style-beam = Beam
+cursor-style-underline = Underline
+cursor-style-hollow-block = Hollow block
+cursor-unfocused-style = Unfocused cursor style
+cursor-blink = Cursor blink
+cursor-blink-respect-terminal = Respect terminal
+cursor-blink-always = Always blink
+cursor-blink-never = Never blink
+cursor-blink-interval = Blink interval
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } millisecond
+   *[other] { $ms } milliseconds
+}
 
 ### Font
 

--- a/i18n/zh-CN/cosmic_term.ftl
+++ b/i18n/zh-CN/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = 暗色模式
 syntax-light = 亮色模式
 default-zoom-step = 缩放步长
 opacity = 背景不透明度
+cursor = 光标
+cursor-color = 光标颜色
+cursor-color-scheme = 使用配色方案
+cursor-color-custom = 自定义颜色
+cursor-color-custom-description = 十六进制颜色（例如 #ff0000）
+cursor-style = 光标样式
+cursor-style-follow-terminal = 跟随终端
+cursor-style-block = 方块
+cursor-style-beam = 竖线
+cursor-style-underline = 下划线
+cursor-style-hollow-block = 空心方块
+cursor-unfocused-style = 未聚焦光标样式
+cursor-blink = 光标闪烁
+cursor-blink-respect-terminal = 跟随终端
+cursor-blink-always = 始终闪烁
+cursor-blink-never = 从不闪烁
+cursor-blink-interval = 闪烁间隔
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } 毫秒
+   *[other] { $ms } 毫秒
+}
 
 ### Font
 

--- a/i18n/zh-TW/cosmic_term.ftl
+++ b/i18n/zh-TW/cosmic_term.ftl
@@ -45,6 +45,27 @@ syntax-dark = 暗色調
 syntax-light = 亮色調
 default-zoom-step = 縮放步進
 opacity = 背景不透明度
+cursor = 游標
+cursor-color = 游標顏色
+cursor-color-scheme = 使用配色方案
+cursor-color-custom = 自訂顏色
+cursor-color-custom-description = 十六進位顏色（例如 #ff0000）
+cursor-style = 游標樣式
+cursor-style-follow-terminal = 跟隨終端機
+cursor-style-block = 方塊
+cursor-style-beam = 直線
+cursor-style-underline = 底線
+cursor-style-hollow-block = 空心方塊
+cursor-unfocused-style = 未聚焦游標樣式
+cursor-blink = 游標閃爍
+cursor-blink-respect-terminal = 跟隨終端機
+cursor-blink-always = 始終閃爍
+cursor-blink-never = 從不閃爍
+cursor-blink-interval = 閃爍間隔
+cursor-blink-interval-description = { $ms ->
+    [one] { $ms } 毫秒
+   *[other] { $ms } 毫秒
+}
 
 ### Font
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+use alacritty_terminal::{term::color::Colors, vte::ansi::Rgb};
 use cosmic::{
     cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry},
     theme,
@@ -11,9 +12,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
-use crate::{fl, localize::LANGUAGE_SORTER, shortcuts::Shortcuts};
+use crate::{cursor::CursorSettings, fl, localize::LANGUAGE_SORTER, shortcuts::Shortcuts};
 
-pub const CONFIG_VERSION: u64 = 1;
+pub const CONFIG_VERSION: u64 = 2;
 pub const COSMIC_THEME_DARK: &str = "COSMIC Dark";
 pub const COSMIC_THEME_LIGHT: &str = "COSMIC Light";
 
@@ -216,6 +217,31 @@ impl Default for Profile {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum CursorColorSource {
+    #[default]
+    ColorScheme,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum CursorStyleSetting {
+    #[default]
+    FollowTerminal,
+    Block,
+    Beam,
+    Underline,
+    HollowBlock,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum CursorBlinkSetting {
+    #[default]
+    RespectTerminal,
+    Always,
+    Never,
+}
+
 #[derive(Clone, CosmicConfigEntry, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     pub app_theme: AppTheme,
@@ -241,6 +267,26 @@ pub struct Config {
     pub default_profile: Option<ProfileId>,
     #[serde(default)]
     pub shortcuts_custom: Shortcuts,
+    #[serde(default)]
+    pub cursor_color_source: CursorColorSource,
+    #[serde(default)]
+    pub cursor_color_custom: Option<HexColor>,
+    #[serde(default)]
+    pub cursor_style: CursorStyleSetting,
+    #[serde(default = "default_cursor_unfocused_style")]
+    pub cursor_unfocused_style: CursorStyleSetting,
+    #[serde(default)]
+    pub cursor_blink: CursorBlinkSetting,
+    #[serde(default = "default_cursor_blink_interval_ms")]
+    pub cursor_blink_interval_ms: u16,
+}
+
+fn default_cursor_unfocused_style() -> CursorStyleSetting {
+    CursorStyleSetting::HollowBlock
+}
+
+fn default_cursor_blink_interval_ms() -> u16 {
+    500
 }
 
 impl Default for Config {
@@ -267,6 +313,12 @@ impl Default for Config {
             use_bright_bold: false,
             default_profile: None,
             shortcuts_custom: Shortcuts::default(),
+            cursor_color_source: CursorColorSource::ColorScheme,
+            cursor_color_custom: None,
+            cursor_style: CursorStyleSetting::FollowTerminal,
+            cursor_unfocused_style: CursorStyleSetting::HollowBlock,
+            cursor_blink: CursorBlinkSetting::RespectTerminal,
+            cursor_blink_interval_ms: 500,
         }
     }
 }
@@ -345,6 +397,14 @@ impl Config {
 
     pub fn opacity_ratio(&self) -> f32 {
         f32::from(self.opacity) / 100.0
+    }
+
+    pub fn cursor_settings(&self) -> CursorSettings {
+        CursorSettings::from(self)
+    }
+
+    pub fn effective_cursor_rgb(&self, colors: &Colors) -> Option<Rgb> {
+        crate::cursor::effective_cursor_rgb(&self.cursor_settings(), colors)
     }
 
     // Get a sorted and adjusted for duplicates list of profile names and ids

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -2,8 +2,9 @@
 
 use alacritty_terminal::{
     term::color::Colors,
-    vte::ansi::{CursorShape, Rgb},
+    vte::ansi::{CursorShape, NamedColor, Rgb},
 };
+use hex_color::HexColor;
 
 use crate::config::{Config, CursorBlinkSetting, CursorColorSource, CursorStyleSetting};
 
@@ -74,6 +75,13 @@ pub fn should_blink(settings: &CursorSettings, is_focused: bool, terminal_blinki
         CursorBlinkSetting::Always => true,
         CursorBlinkSetting::RespectTerminal => terminal_blinking,
     }
+}
+
+/// Default custom cursor color seeded from the active color scheme.
+pub fn scheme_cursor_hex(colors: &Colors) -> Option<HexColor> {
+    colors[NamedColor::Cursor]
+        .or_else(|| colors[NamedColor::Foreground])
+        .map(|rgb| HexColor::rgb(rgb.r, rgb.g, rgb.b))
 }
 
 pub fn effective_cursor_rgb(settings: &CursorSettings, colors: &Colors) -> Option<Rgb> {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use alacritty_terminal::{
+    term::color::Colors,
+    vte::ansi::{CursorShape, Rgb},
+};
+
+use crate::config::{Config, CursorBlinkSetting, CursorColorSource, CursorStyleSetting};
+
+/// Snapshot of cursor-related config passed to renderers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CursorSettings {
+    pub color_source: CursorColorSource,
+    pub color_custom: Option<hex_color::HexColor>,
+    pub style: CursorStyleSetting,
+    pub unfocused_style: CursorStyleSetting,
+    pub blink: CursorBlinkSetting,
+    pub blink_interval_ms: u16,
+}
+
+impl From<&Config> for CursorSettings {
+    fn from(config: &Config) -> Self {
+        Self {
+            color_source: config.cursor_color_source,
+            color_custom: config.cursor_color_custom,
+            style: config.cursor_style,
+            unfocused_style: config.cursor_unfocused_style,
+            blink: config.cursor_blink,
+            blink_interval_ms: config.cursor_blink_interval_ms,
+        }
+    }
+}
+
+impl CursorStyleSetting {
+    pub const fn to_shape(self) -> CursorShape {
+        match self {
+            Self::FollowTerminal => CursorShape::Block,
+            Self::Block => CursorShape::Block,
+            Self::Beam => CursorShape::Beam,
+            Self::Underline => CursorShape::Underline,
+            Self::HollowBlock => CursorShape::HollowBlock,
+        }
+    }
+}
+
+pub fn effective_shape(
+    settings: &CursorSettings,
+    is_focused: bool,
+    terminal_shape: CursorShape,
+) -> CursorShape {
+    if terminal_shape == CursorShape::Hidden {
+        return CursorShape::Hidden;
+    }
+
+    let setting = if is_focused {
+        settings.style
+    } else {
+        settings.unfocused_style
+    };
+
+    match setting {
+        CursorStyleSetting::FollowTerminal => terminal_shape,
+        fixed => fixed.to_shape(),
+    }
+}
+
+pub fn should_blink(settings: &CursorSettings, is_focused: bool, terminal_blinking: bool) -> bool {
+    if !is_focused {
+        return false;
+    }
+
+    match settings.blink {
+        CursorBlinkSetting::Never => false,
+        CursorBlinkSetting::Always => true,
+        CursorBlinkSetting::RespectTerminal => terminal_blinking,
+    }
+}
+
+pub fn effective_cursor_rgb(settings: &CursorSettings, colors: &Colors) -> Option<Rgb> {
+    match settings.color_source {
+        CursorColorSource::ColorScheme => colors[alacritty_terminal::vte::ansi::NamedColor::Cursor],
+        CursorColorSource::Custom => settings.color_custom.map(|hex| Rgb {
+            r: hex.r,
+            g: hex.g,
+            b: hex.b,
+        }),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1682,6 +1682,43 @@ impl App {
         terminal.working_directory()
     }
 
+    /// Default hex color when the user switches to a custom cursor color.
+    /// Seeds from the active color scheme rather than a hardcoded value.
+    fn default_custom_cursor_hex(&self) -> HexColor {
+        // Prefer the focused terminal's palette (may differ from the global scheme).
+        if let Some(tab_model) = self.pane_model.active() {
+            let entity = tab_model.active();
+            if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                let terminal = terminal.lock().unwrap();
+                if let Some(hex) = cursor::scheme_cursor_hex(terminal.colors()) {
+                    return hex;
+                }
+                // Fall back to the live terminal state (e.g. OSC color overrides).
+                let term = terminal.term.lock();
+                if let Some(hex) = cursor::scheme_cursor_hex(term.colors()) {
+                    return hex;
+                }
+            }
+        }
+
+        // No open terminal: use the configured syntax theme.
+        let color_scheme_kind = self.config.color_scheme_kind(self.core.system_theme());
+        let scheme_key = self.config.syntax_theme(color_scheme_kind, None);
+        if let Some(colors) = self.themes.get(&scheme_key)
+            && let Some(hex) = cursor::scheme_cursor_hex(colors)
+        {
+            return hex;
+        }
+
+        // Last resort: built-in COSMIC dark/light themes always define a cursor color.
+        let fallback_colors = match color_scheme_kind {
+            ColorSchemeKind::Dark => terminal_theme::cosmic_dark(),
+            ColorSchemeKind::Light => terminal_theme::cosmic_light(),
+        };
+        cursor::scheme_cursor_hex(&fallback_colors)
+            .expect("builtin color scheme defines a cursor color")
+    }
+
     fn create_and_focus_new_terminal(
         &mut self,
         pane: pane_grid::Pane,
@@ -1979,11 +2016,20 @@ impl Application for App {
             fl!("cursor-blink-never"),
         ];
 
+        let color_scheme_kind = flags.config.color_scheme_kind(core.system_theme());
+        let fallback_colors = match color_scheme_kind {
+            ColorSchemeKind::Dark => terminal_theme::cosmic_dark(),
+            ColorSchemeKind::Light => terminal_theme::cosmic_light(),
+        };
         let cursor_color_custom_input = flags
             .config
             .cursor_color_custom
             .map(|hex| hex.display_rgb().to_string())
-            .unwrap_or_else(|| "#ffffff".to_string());
+            .unwrap_or_else(|| {
+                cursor::scheme_cursor_hex(&fallback_colors)
+                    .map(|hex| hex.display_rgb().to_string())
+                    .unwrap_or_default()
+            });
 
         let pane_model = TerminalPaneGrid::new(segmented_button::ModelBuilder::default().build());
         let mut terminal_ids = HashMap::new();
@@ -2357,7 +2403,9 @@ impl Application for App {
                         .config
                         .cursor_color_custom
                         .map(|hex| hex.display_rgb().to_string())
-                        .unwrap_or_else(|| "#ffffff".to_string());
+                        .unwrap_or_else(|| {
+                            self.default_custom_cursor_hex().display_rgb().to_string()
+                        });
                     if shortcuts_changed {
                         self.shortcuts_config =
                             shortcuts::ShortcutsConfig::new(self.config.shortcuts_custom.clone());
@@ -2780,7 +2828,7 @@ impl Application for App {
                 config_set!(cursor_color_source, source);
                 if source == CursorColorSource::Custom && self.config.cursor_color_custom.is_none()
                 {
-                    let hex = HexColor::rgb(255, 255, 255);
+                    let hex = self.default_custom_cursor_hex();
                     config_set!(cursor_color_custom, Some(hex));
                     self.cursor_color_custom_input = hex.display_rgb().to_string();
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use cosmic::{
 use cosmic::{Apply, surface};
 use cosmic_files::dialog::{Dialog, DialogKind, DialogMessage, DialogResult, DialogSettings};
 use cosmic_text::{Family, Stretch, Weight, fontdb::FaceInfo};
+use hex_color::HexColor;
 use localize::LANGUAGE_SORTER;
 use std::{
     any::TypeId,
@@ -42,14 +43,16 @@ use std::{
     process,
     rc::Rc,
     sync::{LazyLock, Mutex, atomic::Ordering},
+    time::Duration,
 };
 use tokio::sync::mpsc;
 
 use config::{
-    AppTheme, CONFIG_VERSION, ColorScheme, ColorSchemeId, ColorSchemeKind, Config, Profile,
-    ProfileId,
+    AppTheme, CONFIG_VERSION, ColorScheme, ColorSchemeId, ColorSchemeKind, Config,
+    CursorBlinkSetting, CursorColorSource, CursorStyleSetting, Profile, ProfileId,
 };
 mod config;
+mod cursor;
 mod mouse_reporter;
 
 use icon_cache::IconCache;
@@ -456,6 +459,13 @@ pub enum Message {
     ZoomOut,
     ZoomReset,
     ContextMenuPopupClosed(window::Id),
+    CursorBlinkTick,
+    CursorBlinkInterval(u16),
+    CursorBlinkSetting(CursorBlinkSetting),
+    CursorColorCustom(String),
+    CursorColorSource(CursorColorSource),
+    CursorStyle(CursorStyleSetting),
+    CursorUnfocusedStyle(CursorStyleSetting),
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -498,6 +508,9 @@ pub struct App {
     curr_font_stretches: Vec<Stretch>,
     zoom_step_names: Vec<String>,
     zoom_steps: Vec<u16>,
+    cursor_color_names: Vec<String>,
+    cursor_style_names: Vec<String>,
+    cursor_blink_names: Vec<String>,
     theme_names_dark: Vec<String>,
     theme_names_light: Vec<String>,
     themes: HashMap<(String, ColorSchemeKind), TermColors>,
@@ -525,6 +538,11 @@ pub struct App {
     shortcut_search_id: widget::Id,
     shortcut_search_regex: Option<regex::Regex>,
     shortcut_search_value: String,
+    cursor_color_custom_input: String,
+    cursor_color_dropdown_id: widget::Id,
+    cursor_style_dropdown_id: widget::Id,
+    cursor_unfocused_style_dropdown_id: widget::Id,
+    cursor_blink_dropdown_id: widget::Id,
     modifiers: Modifiers,
     context_menu_popup: Option<(
         window::Id,
@@ -704,6 +722,12 @@ impl App {
 
         // Update application theme
         cosmic::command::set_theme(theme)
+    }
+
+    fn update_cursor_config(&mut self) -> Task<Message> {
+        let task = self.update_config();
+        self.pane_model.refresh_all_cursor_displays();
+        task
     }
 
     fn update_render_active_pane_zoom(&mut self, zoom_message: Message) -> Task<Message> {
@@ -1373,6 +1397,23 @@ impl App {
             .iter()
             .position(|zoom_step| zoom_step == &self.config.font_size_zoom_step_mul_100);
 
+        let cursor_color_selected = match self.config.cursor_color_source {
+            CursorColorSource::ColorScheme => 0,
+            CursorColorSource::Custom => 1,
+        };
+        let cursor_style_selected = |style: CursorStyleSetting| match style {
+            CursorStyleSetting::FollowTerminal => 0,
+            CursorStyleSetting::Block => 1,
+            CursorStyleSetting::Beam => 2,
+            CursorStyleSetting::Underline => 3,
+            CursorStyleSetting::HollowBlock => 4,
+        };
+        let cursor_blink_selected = match self.config.cursor_blink {
+            CursorBlinkSetting::RespectTerminal => 0,
+            CursorBlinkSetting::Always => 1,
+            CursorBlinkSetting::Never => 2,
+        };
+
         let appearance_section = widget::settings::section()
             .title(fl!("appearance"))
             .add(
@@ -1417,7 +1458,98 @@ impl App {
                     .control(widget::slider(0..=100, self.config.opacity, |opacity| {
                         Message::Opacity(opacity)
                     }))
-            }));
+            }))
+            .add(
+                widget::settings::item::builder(fl!("cursor-color")).control(
+                    widget::dropdown(
+                        &self.cursor_color_names,
+                        Some(cursor_color_selected),
+                        |index| {
+                            Message::CursorColorSource(match index {
+                                1 => CursorColorSource::Custom,
+                                _ => CursorColorSource::ColorScheme,
+                            })
+                        },
+                    )
+                    .id(self.cursor_color_dropdown_id.clone()),
+                ),
+            )
+            .add_maybe(
+                (self.config.cursor_color_source == CursorColorSource::Custom).then(|| {
+                    widget::settings::item::builder(fl!("cursor-color-custom"))
+                        .description(fl!("cursor-color-custom-description"))
+                        .control(
+                            widget::text_input("", &self.cursor_color_custom_input)
+                                .on_input(Message::CursorColorCustom),
+                        )
+                }),
+            )
+            .add(
+                widget::settings::item::builder(fl!("cursor-style")).control(
+                    widget::dropdown(
+                        &self.cursor_style_names,
+                        Some(cursor_style_selected(self.config.cursor_style)),
+                        |index| {
+                            Message::CursorStyle(match index {
+                                1 => CursorStyleSetting::Block,
+                                2 => CursorStyleSetting::Beam,
+                                3 => CursorStyleSetting::Underline,
+                                4 => CursorStyleSetting::HollowBlock,
+                                _ => CursorStyleSetting::FollowTerminal,
+                            })
+                        },
+                    )
+                    .id(self.cursor_style_dropdown_id.clone()),
+                ),
+            )
+            .add(
+                widget::settings::item::builder(fl!("cursor-unfocused-style")).control(
+                    widget::dropdown(
+                        &self.cursor_style_names,
+                        Some(cursor_style_selected(self.config.cursor_unfocused_style)),
+                        |index| {
+                            Message::CursorUnfocusedStyle(match index {
+                                1 => CursorStyleSetting::Block,
+                                2 => CursorStyleSetting::Beam,
+                                3 => CursorStyleSetting::Underline,
+                                4 => CursorStyleSetting::HollowBlock,
+                                _ => CursorStyleSetting::FollowTerminal,
+                            })
+                        },
+                    )
+                    .id(self.cursor_unfocused_style_dropdown_id.clone()),
+                ),
+            )
+            .add(
+                widget::settings::item::builder(fl!("cursor-blink")).control(
+                    widget::dropdown(
+                        &self.cursor_blink_names,
+                        Some(cursor_blink_selected),
+                        |index| {
+                            Message::CursorBlinkSetting(match index {
+                                1 => CursorBlinkSetting::Always,
+                                2 => CursorBlinkSetting::Never,
+                                _ => CursorBlinkSetting::RespectTerminal,
+                            })
+                        },
+                    )
+                    .id(self.cursor_blink_dropdown_id.clone()),
+                ),
+            )
+            .add_maybe(
+                (self.config.cursor_blink != CursorBlinkSetting::Never).then(|| {
+                    widget::settings::item::builder(fl!("cursor-blink-interval"))
+                        .description(fl!(
+                            "cursor-blink-interval-description",
+                            ms = self.config.cursor_blink_interval_ms
+                        ))
+                        .control(widget::slider(
+                            100..=2000,
+                            self.config.cursor_blink_interval_ms,
+                            Message::CursorBlinkInterval,
+                        ))
+                }),
+            );
 
         let mut font_section = widget::settings::section()
             .title(fl!("font"))
@@ -1833,6 +1965,26 @@ impl Application for App {
             zoom_steps.push(zoom_step);
         }
 
+        let cursor_color_names = vec![fl!("cursor-color-scheme"), fl!("cursor-color-custom")];
+        let cursor_style_names = vec![
+            fl!("cursor-style-follow-terminal"),
+            fl!("cursor-style-block"),
+            fl!("cursor-style-beam"),
+            fl!("cursor-style-underline"),
+            fl!("cursor-style-hollow-block"),
+        ];
+        let cursor_blink_names = vec![
+            fl!("cursor-blink-respect-terminal"),
+            fl!("cursor-blink-always"),
+            fl!("cursor-blink-never"),
+        ];
+
+        let cursor_color_custom_input = flags
+            .config
+            .cursor_color_custom
+            .map(|hex| hex.display_rgb().to_string())
+            .unwrap_or_else(|| "#ffffff".to_string());
+
         let pane_model = TerminalPaneGrid::new(segmented_button::ModelBuilder::default().build());
         let mut terminal_ids = HashMap::new();
         terminal_ids.insert(pane_model.focused(), widget::Id::unique());
@@ -1876,6 +2028,9 @@ impl Application for App {
             curr_font_stretches: Vec::new(),
             zoom_step_names,
             zoom_steps,
+            cursor_color_names,
+            cursor_style_names,
+            cursor_blink_names,
             theme_names_dark: Vec::new(),
             theme_names_light: Vec::new(),
             themes: HashMap::new(),
@@ -1902,6 +2057,11 @@ impl Application for App {
             shortcut_search_id: widget::Id::unique(),
             shortcut_search_regex: None,
             shortcut_search_value: String::new(),
+            cursor_color_custom_input,
+            cursor_color_dropdown_id: widget::Id::unique(),
+            cursor_style_dropdown_id: widget::Id::unique(),
+            cursor_unfocused_style_dropdown_id: widget::Id::unique(),
+            cursor_blink_dropdown_id: widget::Id::unique(),
             modifiers: Modifiers::empty(),
             context_menu_popup: None,
             #[cfg(feature = "password_manager")]
@@ -2193,6 +2353,11 @@ impl Application for App {
                     log::info!("update config");
                     //TODO: update syntax theme by clearing tabs, only if needed
                     self.config = *config;
+                    self.cursor_color_custom_input = self
+                        .config
+                        .cursor_color_custom
+                        .map(|hex| hex.display_rgb().to_string())
+                        .unwrap_or_else(|| "#ffffff".to_string());
                     if shortcuts_changed {
                         self.shortcuts_config =
                             shortcuts::ShortcutsConfig::new(self.config.shortcuts_custom.clone());
@@ -2586,6 +2751,48 @@ impl Application for App {
             }
             Message::Opacity(opacity) => {
                 config_set!(opacity, cmp::min(100, opacity));
+            }
+            Message::CursorBlinkTick => {
+                self.pane_model.toggle_focused_cursor_blink();
+            }
+            Message::CursorBlinkInterval(interval_ms) => {
+                config_set!(cursor_blink_interval_ms, interval_ms.clamp(100, 2000));
+                return self.update_cursor_config();
+            }
+            Message::CursorBlinkSetting(blink) => {
+                config_set!(cursor_blink, blink);
+                return self.update_cursor_config();
+            }
+            Message::CursorColorCustom(value) => {
+                self.cursor_color_custom_input = value.clone();
+                let value = value.trim();
+                let parse_value = if value.starts_with('#') {
+                    value.to_string()
+                } else {
+                    format!("#{value}")
+                };
+                if let Ok(hex) = parse_value.parse::<HexColor>() {
+                    config_set!(cursor_color_custom, Some(hex));
+                    return self.update_cursor_config();
+                }
+            }
+            Message::CursorColorSource(source) => {
+                config_set!(cursor_color_source, source);
+                if source == CursorColorSource::Custom && self.config.cursor_color_custom.is_none()
+                {
+                    let hex = HexColor::rgb(255, 255, 255);
+                    config_set!(cursor_color_custom, Some(hex));
+                    self.cursor_color_custom_input = hex.display_rgb().to_string();
+                }
+                return self.update_cursor_config();
+            }
+            Message::CursorStyle(style) => {
+                config_set!(cursor_style, style);
+                return self.update_cursor_config();
+            }
+            Message::CursorUnfocusedStyle(style) => {
+                config_set!(cursor_unfocused_style, style);
+                return self.update_cursor_config();
             }
             Message::PaneClicked(pane) => {
                 self.pane_model.set_focus(pane);
@@ -3088,7 +3295,14 @@ impl Application for App {
                         }
                     }
                     TermEvent::CursorBlinkingChange => {
-                        //TODO: should we blink the cursor?
+                        if let Some(tab_model) = self.pane_model.panes.get(pane)
+                            && let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity)
+                        {
+                            let mut terminal = terminal.lock().unwrap();
+                            terminal.cursor_blink_visible = true;
+                            terminal.needs_update = true;
+                            terminal.update();
+                        }
                     }
                     TermEvent::Exit => {
                         return self.update(Message::TabClose(Some(entity)));
@@ -3205,7 +3419,14 @@ impl Application for App {
                 } else {
                     self.context_page = context_page;
                     self.core.window.show_context = true;
-                    self.pane_model.unfocus_all_terminals();
+                    match context_page {
+                        ContextPage::KeyboardShortcuts => {
+                            self.pane_model.unfocus_all_terminals();
+                        }
+                        _ => {
+                            self.pane_model.update_terminal_focus();
+                        }
+                    }
                 }
 
                 // Extra work to do to prepare context pages
@@ -3671,6 +3892,17 @@ impl Application for App {
         struct ConfigSubscription;
         struct TerminalEventSubscription;
 
+        let cursor_blink_sub = if self.config.cursor_blink != CursorBlinkSetting::Never
+            && self.pane_model.any_focused_terminal_should_blink()
+        {
+            cosmic::iced::time::every(Duration::from_millis(
+                self.config.cursor_blink_interval_ms as u64,
+            ))
+            .map(|_| Message::CursorBlinkTick)
+        } else {
+            Subscription::none()
+        };
+
         Subscription::batch([
             event::listen_with(|event, _status, _window_id| match event {
                 Event::Keyboard(KeyEvent::KeyPressed {
@@ -3724,6 +3956,7 @@ impl Application for App {
                 Some(dialog) => dialog.subscription(),
                 None => Subscription::none(),
             },
+            cursor_blink_sub,
         ])
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -41,6 +41,7 @@ pub use alacritty_terminal::grid::Scroll as TerminalScroll;
 
 use crate::{
     config::{ColorSchemeKind, Config as AppConfig, ProfileId},
+    cursor::{CursorSettings, effective_shape, should_blink},
     menu::MenuState,
     mouse_reporter::MouseReporter,
 };
@@ -196,12 +197,58 @@ impl TerminalPaneGrid {
         }
     }
     pub fn unfocus_all_terminals(&self) {
-        for (_pane, tab_model) in self.panes.panes.iter() {
+        for tab_model in self.panes.panes.values() {
             let entity = tab_model.active();
             if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
                 let mut terminal = terminal.lock().unwrap();
                 terminal.set_focused(false);
                 terminal.update();
+            }
+        }
+    }
+
+    pub fn any_focused_terminal_should_blink(&self) -> bool {
+        for (pane, tab_model) in self.panes.panes.iter() {
+            if self.focus != *pane {
+                continue;
+            }
+            let entity = tab_model.active();
+            if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                let terminal = terminal.lock().unwrap();
+                if terminal.should_blink() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn refresh_all_cursor_displays(&self) {
+        for tab_model in self.panes.panes.values() {
+            for entity in tab_model.iter() {
+                if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                    let mut terminal = terminal.lock().unwrap();
+                    terminal.refresh_cursor_display();
+                }
+            }
+        }
+    }
+
+    pub fn toggle_focused_cursor_blink(&self) {
+        for (pane, tab_model) in self.panes.panes.iter() {
+            if self.focus != *pane {
+                continue;
+            }
+            let entity = tab_model.active();
+            if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                let mut terminal = terminal.lock().unwrap();
+                if terminal.should_blink() {
+                    let visible = !terminal.cursor_blink_visible;
+                    terminal.set_cursor_blink_visible(visible);
+                    if terminal.needs_update {
+                        terminal.update();
+                    }
+                }
             }
         }
     }
@@ -261,6 +308,8 @@ pub struct Terminal {
     size: Size,
     use_bright_bold: bool,
     zoom_adj: i8,
+    pub cursor_blink_visible: bool,
+    cursor_settings: CursorSettings,
 }
 
 impl Terminal {
@@ -365,6 +414,8 @@ impl Terminal {
             use_bright_bold,
             zoom_adj: Default::default(),
             is_focused: true,
+            cursor_blink_visible: true,
+            cursor_settings: CursorSettings::from(app_config),
         })
     }
 
@@ -420,6 +471,9 @@ impl Terminal {
         self.is_focused = is_focused;
 
         if focus_changed {
+            self.cursor_blink_visible = true;
+            self.needs_update = true;
+
             let report_focus = self.term.lock().mode().contains(TermMode::FOCUS_IN_OUT);
             if report_focus {
                 const FOCUS_IN: &[u8] = b"\x1b[I";
@@ -428,6 +482,44 @@ impl Terminal {
                 let input = if is_focused { FOCUS_IN } else { FOCUS_OUT };
                 self.input_no_scroll(input);
             }
+        }
+    }
+
+    pub fn cursor_settings(&self) -> CursorSettings {
+        self.cursor_settings
+    }
+
+    pub fn should_blink(&self) -> bool {
+        let term = self.term.lock();
+        should_blink(
+            &self.cursor_settings,
+            self.is_focused,
+            term.cursor_style().blinking,
+        )
+    }
+
+    pub fn is_focused(&self) -> bool {
+        self.is_focused
+    }
+
+    pub fn refresh_cursor_display(&mut self) {
+        self.cursor_blink_visible = true;
+        self.set_redraw(true);
+        self.needs_update = true;
+        self.update();
+    }
+
+    pub fn set_cursor_blink_visible(&mut self, visible: bool) {
+        if self.cursor_blink_visible == visible {
+            return;
+        }
+        self.cursor_blink_visible = visible;
+        let term = self.term.lock();
+        let terminal_shape = term.renderable_content().cursor.shape;
+        drop(term);
+        let shape = effective_shape(&self.cursor_settings, self.is_focused, terminal_shape);
+        if shape == CursorShape::Block {
+            self.needs_update = true;
         }
     }
 
@@ -695,9 +787,22 @@ impl Terminal {
                     changed = true;
                 }
             }
+            if config.cursor_color_source == crate::config::CursorColorSource::Custom {
+                let cursor_rgb = config.effective_cursor_rgb(&self.colors);
+                if self.colors[NamedColor::Cursor] != cursor_rgb {
+                    self.colors[NamedColor::Cursor] = cursor_rgb;
+                    changed = true;
+                }
+            }
             if changed {
                 update = true;
             }
+        }
+
+        let changed_cursor_settings = self.cursor_settings != CursorSettings::from(config);
+        self.cursor_settings = CursorSettings::from(config);
+        if changed_cursor_settings {
+            update = true;
         }
 
         // NOTE: this is done on every set_config because the changed boolean above does not capture
@@ -804,6 +909,9 @@ impl Terminal {
                 }
 
                 let grid = term.grid();
+                let terminal_shape = term.renderable_content().cursor.shape;
+                let effective_cursor_shape =
+                    effective_shape(&self.cursor_settings, self.is_focused, terminal_shape);
                 for indexed in grid.display_iter() {
                     if indexed.point.line != last_point.unwrap_or(indexed.point).line {
                         while line_i >= buffer.lines.len() {
@@ -878,8 +986,9 @@ impl Terminal {
 
                     // Change color if cursor
                     if indexed.point == grid.cursor.point
-                        && term.renderable_content().cursor.shape == CursorShape::Block
+                        && effective_cursor_shape == CursorShape::Block
                         && self.is_focused
+                        && self.cursor_blink_visible
                     {
                         //Use specific cursor color if requested
                         if term.colors()[NamedColor::Cursor].is_some() {

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -46,7 +46,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{Action, Terminal, TerminalScroll, menu::MenuState, terminal::Metadata};
+use crate::{
+    Action, Terminal, TerminalScroll, cursor::effective_shape, menu::MenuState, terminal::Metadata,
+};
 
 const AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -527,12 +529,11 @@ where
                         &mut self,
                         glyph: &LayoutGlyph,
                         renderer: &mut Renderer,
-                        is_focused: bool,
                     ) {
                         if glyph.metadata == self.metadata {
                             self.end_x = glyph.x + glyph.w;
                         } else {
-                            self.fill(renderer, is_focused);
+                            self.fill(renderer);
                             self.metadata = glyph.metadata;
                             self.glyph_font_size = glyph.font_size;
                             self.start_x = glyph.x;
@@ -540,11 +541,7 @@ where
                         }
                     }
 
-                    fn fill<Renderer: renderer::Renderer>(
-                        &mut self,
-                        renderer: &mut Renderer,
-                        is_focused: bool,
-                    ) {
+                    fn fill<Renderer: renderer::Renderer>(&mut self, renderer: &mut Renderer) {
                         let cosmic_text_to_iced_color = |color: cosmic_text::Color| {
                             Color::from_rgba(
                                 f32::from(color.r()) / 255.0,
@@ -717,9 +714,9 @@ where
                     metadata_set,
                 };
                 for glyph in run.glyphs {
-                    bg_rect.update(glyph, renderer, state.is_focused);
+                    bg_rect.update(glyph, renderer);
                 }
-                bg_rect.fill(renderer, state.is_focused);
+                bg_rect.fill(renderer);
             }
         });
 
@@ -811,21 +808,29 @@ where
             let cursor = term.renderable_content().cursor;
             drop(term);
 
-            // Skip drawing cursor when scrolled - the cursor is below the visible viewport
-            if display_offset > 0 {
-                // Cursor is off-screen when scrolled up
-            } else {
+            let cursor_settings = terminal.cursor_settings();
+            let is_focused = terminal.is_focused();
+            let effective = effective_shape(&cursor_settings, is_focused, cursor.shape);
+
+            if display_offset == 0
+                && effective != CursorShape::Hidden
+                && terminal.cursor_blink_visible
+            {
                 let col = cursor.point.column.0;
                 let line = cursor.point.line.0;
-                let color = terminal.term.lock().colors()[NamedColor::Cursor]
-                    .or(terminal.colors()[NamedColor::Cursor])
+                let color = terminal.colors()[NamedColor::Cursor]
+                    .or_else(|| terminal.term.lock().colors()[NamedColor::Cursor])
                     .map(|rgb| Color::from_rgb8(rgb.r, rgb.g, rgb.b))
-                    .unwrap_or(Color::WHITE); // TODO default color from theme?
+                    .or_else(|| {
+                        terminal.colors()[NamedColor::Foreground]
+                            .map(|rgb| Color::from_rgb8(rgb.r, rgb.g, rgb.b))
+                    })
+                    .unwrap_or(Color::WHITE);
                 let width = terminal.size().cell_width;
                 let height = terminal.size().cell_height;
                 let top_left = view_position
                     + Vector::new((col as f32 * width).floor(), (line as f32 * height).floor());
-                match cursor.shape {
+                match effective {
                     CursorShape::Beam => {
                         let quad = Quad {
                             bounds: Rectangle::new(top_left, Size::new(1.0, height)),
@@ -847,7 +852,7 @@ where
                         };
                         renderer.fill_quad(quad, color);
                     }
-                    CursorShape::Block if !state.is_focused => {
+                    CursorShape::Block if !is_focused => {
                         let quad = Quad {
                             bounds: Rectangle::new(top_left, Size::new(width, height)),
                             border: Border {
@@ -871,7 +876,7 @@ where
                         };
                         renderer.fill_quad(quad, Color::TRANSPARENT);
                     }
-                    CursorShape::Block | CursorShape::Hidden => {} // Block is handled seperately
+                    CursorShape::Block | CursorShape::Hidden => {} // Block is handled separately
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds user-configurable cursor settings to COSMIC Terminal: color (scheme or custom), focused/unfocused style (block, beam, underline, hollow block, or follow terminal), and blink behavior with interval.

Addresses [pop-os/cosmic-epoch#522](https://github.com/pop-os/cosmic-epoch/issues/522) — users can now set a beam (I-beam) cursor in settings instead of relying on the terminal emulator alone.

### Related work (not in this PR)

Cursor fade in/out is also requested in [pop-os/cosmic-epoch#603](https://github.com/pop-os/cosmic-epoch/issues/603). An experimental implementation lives on my fork in [`cursor_options_fade`](https://github.com/gRoussac/cosmic-term/tree/cursor_options_fade). I am keeping fade out of this PR because it needs a larger rework for block cursors; I would rather land the core cursor options first and follow up separately.

- [x] I have disclosed use of any AI generated code in my commit messages.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

## Test plan

- [x] Open Settings → Appearance → Cursor and verify color, style, unfocused style, and blink options
- [x] Set cursor style to **Beam** and confirm I-beam renders when focused
- [x] Set unfocused style to **Hollow block** and confirm behavior when window loses focus
- [x] Set custom cursor color and confirm it overrides the color scheme (default should match the active scheme, not hardcoded white)
- [x] Toggle blink settings (respect terminal / always / never) and confirm behavior
- [x] Restart the app and confirm settings persist (config v2)