### PR TITLE
feat: Dropdown terminal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1"
 ron = "0.11"
 serde = { version = "1", features = ["serde_derive"] }
 shlex = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "signal", "time"] }
 # CLI arguments
 clap_lex = "0.7"
 # Internationalization

--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -64,6 +64,7 @@ show-pane-borders = Show pane borders
 advanced = Advanced
 show-headerbar = Show header
 show-header-description = Reveal the header from the right-click menu
+show-headerbar-dropdown = Show header in dropdown
 tab-new-inherit-working-directory = New tabs and windows use current directory
 tab-new-inherit-working-directory-description = Open new tabs and windows in the active tab's working directory
 
@@ -95,6 +96,10 @@ shortcut-replace-title = Replace shortcut?
 tab-activate = Activate tab { $number }
 toggle-fullscreen = Toggle fullscreen
 type-to-search = Type to search...
+
+# Drop-down
+dropdown = Drop-down
+dropdown-height = Height
 
 # Find
 find-placeholder = Find...

--- a/src/config.rs
+++ b/src/config.rs
@@ -232,6 +232,9 @@ pub struct Config {
     pub profiles: BTreeMap<ProfileId, Profile>,
     pub show_headerbar: bool,
     pub show_pane_borders: bool,
+    #[serde(default)]
+    pub show_headerbar_dropdown: bool,
+    pub dropdown_height: u32,
     pub use_bright_bold: bool,
     pub syntax_theme_dark: String,
     pub syntax_theme_light: String,
@@ -262,6 +265,8 @@ impl Default for Config {
             profiles: BTreeMap::new(),
             show_headerbar: true,
             show_pane_borders: false,
+            show_headerbar_dropdown: true,
+            dropdown_height: 500,
             syntax_theme_dark: COSMIC_THEME_DARK.to_string(),
             syntax_theme_light: COSMIC_THEME_LIGHT.to_string(),
             use_bright_bold: false,

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -1,0 +1,160 @@
+use cosmic::Application;
+use cosmic::iced::{
+    self, Subscription,
+    futures::SinkExt,
+    platform_specific::runtime::wayland::layer_surface::SctkLayerSurfaceSettings,
+    platform_specific::shell::commands::layer_surface::{
+        Anchor, KeyboardInteractivity, Layer, destroy_layer_surface, get_layer_surface,
+    },
+    stream, window,
+};
+use cosmic::style;
+use cosmic::widget;
+use std::any::TypeId;
+
+use crate::App;
+use crate::Message;
+
+/// Scan /proc for an existing cosmic-term process with --drop-down flag.
+pub fn find_existing_dropdown_pid() -> Option<u32> {
+    let current_pid = std::process::id();
+    let proc_dir = match std::fs::read_dir("/proc") {
+        Ok(d) => d,
+        Err(_) => return None,
+    };
+    for entry in proc_dir.flatten() {
+        if let Some(pid) = entry
+            .file_name()
+            .to_string_lossy()
+            .parse::<u32>()
+            .ok()
+            .filter(|&p| p != current_pid)
+            .and_then(|pid| {
+                std::fs::read(entry.path().join("cmdline"))
+                    .ok()
+                    .filter(|cmdline| {
+                        let args: Vec<&[u8]> = cmdline.split(|b| *b == 0).collect();
+                        args.iter().any(|a| {
+                            a.ends_with(b"cosmic-term")
+                                || a.ends_with(b"cosmic-term\n")
+                                || a == b"cosmic-term"
+                        }) && args.iter().any(|a| *a == b"--drop-down")
+                    })
+                    .map(|_| pid)
+            })
+        {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+impl App {
+    pub fn create_dropdown_layer_surface(
+        id: window::Id,
+        height_px: u32,
+    ) -> cosmic::app::Task<Message> {
+        get_layer_surface(SctkLayerSurfaceSettings {
+            id,
+            keyboard_interactivity: KeyboardInteractivity::OnDemand,
+            anchor: Anchor::TOP | Anchor::LEFT | Anchor::RIGHT,
+            namespace: "cosmic-term-dropdown".into(),
+            layer: Layer::Overlay,
+            size: Some((None, Some(height_px))),
+            ..Default::default()
+        })
+    }
+
+    /// Returns a valid parent window ID for popups.
+    pub fn popup_parent_id(&self) -> Option<window::Id> {
+        self.dropdown_surface.or_else(|| self.core.main_window_id())
+    }
+
+    /// Destroy and recreate the current dropdown surface (e.g. after a config change).
+    /// Uses `height_override` if provided, otherwise uses `self.config.dropdown_height`.
+    pub fn recreate_dropdown_surface(
+        &self,
+        height_override: Option<u32>,
+    ) -> cosmic::app::Task<Message> {
+        if let Some(id) = self.dropdown_surface {
+            let height = height_override.unwrap_or(self.config.dropdown_height);
+            cosmic::app::Task::batch([
+                destroy_layer_surface(id),
+                Self::create_dropdown_layer_surface(id, height),
+            ])
+        } else {
+            cosmic::app::Task::none()
+        }
+    }
+
+    /// Subscription for SIGUSR1 signal handling in drop-down mode.
+    pub fn subscribe_dropdown_signals(&self) -> Subscription<Message> {
+        struct DropDownSignalSubscription;
+
+        Subscription::run_with(TypeId::of::<DropDownSignalSubscription>(), |_| {
+            stream::channel(
+                1,
+                |mut output: iced::futures::channel::mpsc::Sender<Message>| async move {
+                    let mut signal_stream = match tokio::signal::unix::signal(
+                        tokio::signal::unix::SignalKind::user_defined1(),
+                    ) {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            log::error!("Failed to create signal stream: {}", e);
+                            return;
+                        }
+                    };
+
+                    loop {
+                        signal_stream.recv().await;
+                        let _ = output.send(Message::ToggleDropDown).await;
+                    }
+                },
+            )
+        })
+    }
+
+    /// In drop-down mode, `view_main()` is bypassed. Wrap the terminal view
+    /// with the header bar and context drawer ourselves.
+    pub fn wrap_dropdown_view<'a>(
+        &'a self,
+        view: cosmic::Element<'a, Message>,
+    ) -> cosmic::Element<'a, Message> {
+        let mut view = view;
+
+        if self.core.window.show_context
+            && let Some(context) = self.context_drawer()
+        {
+            view = widget::context_drawer(
+                context.title,
+                context.actions,
+                context.header,
+                context.footer,
+                context.on_close,
+                view,
+                context.content,
+                320.0,
+            )
+            .into();
+        }
+
+        if self.config.show_headerbar_dropdown {
+            let mut header = widget::header_bar();
+            for el in self.header_start() {
+                header = header.start(el);
+            }
+            for el in self.header_end() {
+                header = header.end(el);
+            }
+
+            // Wrap header in themed container — layer surface has no window chrome.
+            let header = widget::container(header)
+                .class(style::Container::WindowBackground)
+                .width(iced::Length::Fill);
+
+            view = widget::column::with_children(vec![header.into(), view]).into();
+        }
+
+        view
+    }
+}

--- a/src/dropdown.rs
+++ b/src/dropdown.rs
@@ -140,8 +140,13 @@ impl App {
 
         if self.config.show_headerbar_dropdown {
             let mut header = widget::header_bar();
-            for el in self.header_start() {
-                header = header.start(el);
+            if let Some(parent_id) = self.dropdown_surface {
+                header = header.start(crate::menu::menu_bar(
+                    &self.core,
+                    &self.config,
+                    &self.key_binds,
+                    Some(parent_id),
+                ));
             }
             for el in self.header_end() {
                 header = header.end(el);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use cosmic::{
         futures::SinkExt,
         keyboard::{Event as KeyEvent, Key, Modifiers},
         mouse::{Button as MouseButton, Event as MouseEvent},
+        platform_specific::shell::commands::layer_surface::destroy_layer_surface,
         stream, window,
     },
     style,
@@ -79,6 +80,7 @@ mod password_manager;
 mod terminal_theme;
 
 mod dnd;
+mod dropdown;
 
 use clap_lex::RawArgs;
 
@@ -98,6 +100,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut shell_program_opt = None;
     let mut shell_args = Vec::new();
     let mut daemonize = true;
+    let mut drop_down = false;
     let mut working_directory = None;
     // Parse the arguments using clap_lex
     while let Some(arg) = raw_args.next_os(&mut cursor) {
@@ -123,6 +126,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             Some("--no-daemon") => {
                 daemonize = false;
+            }
+            Some("--drop-down") => {
+                drop_down = true;
             }
             Some("-e") | Some("--command") | Some("--") => {
                 // Handle the '--command' or '-e' flag
@@ -158,6 +164,23 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     localize::localize();
+
+    // Drop-down mode single-instance handling:
+    // scan /proc for an existing cosmic-term --drop-down process.
+    if drop_down {
+        // Look for a running cosmic-term --drop-down process.
+        if let Some(pid) = dropdown::find_existing_dropdown_pid() {
+            log::info!(
+                "Found existing drop-down instance (PID {}), sending toggle signal and exiting",
+                pid
+            );
+            let _ = std::process::Command::new("kill")
+                .arg("-USR1")
+                .arg(pid.to_string())
+                .spawn();
+            return Ok(());
+        }
+    }
 
     let (config_handler, config) = match cosmic_config::Config::new(App::APP_ID, CONFIG_VERSION) {
         Ok(config_handler) => {
@@ -202,6 +225,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     settings = settings.theme(config.app_theme.theme());
     settings = settings.size_limits(Limits::NONE.min_width(360.0).min_height(180.0));
 
+    if drop_down {
+        settings = settings.no_main_window(true);
+    }
+
     // Flags
     let flags = Flags {
         config_handler,
@@ -209,6 +236,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         shortcuts_config,
         startup_options,
         term_config,
+        drop_down,
     };
 
     // Run the cosmic app
@@ -237,6 +265,7 @@ pub struct Flags {
     shortcuts_config: shortcuts::ShortcutsConfig,
     startup_options: Option<tty::Options>,
     term_config: term::Config,
+    drop_down: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -267,6 +296,7 @@ pub enum Action {
     #[cfg(feature = "password_manager")]
     PasswordManager,
     ShowHeaderBar(bool),
+    ShowHeaderBarDropdown(bool),
     TabActivate0,
     TabActivate1,
     TabActivate2,
@@ -281,6 +311,7 @@ pub enum Action {
     TabNewNoProfile,
     TabNext,
     TabPrev,
+    ToggleDropDown,
     ToggleFullscreen,
     WindowClose,
     WindowNew,
@@ -320,6 +351,9 @@ impl Action {
             Self::SelectAll => Message::SelectAll(entity_opt),
             Self::Settings => Message::ToggleContextPage(ContextPage::Settings),
             Self::ShowHeaderBar(show_headerbar) => Message::ShowHeaderBar(*show_headerbar),
+            Self::ShowHeaderBarDropdown(show_headerbar) => {
+                Message::ShowHeaderBarDropdown(*show_headerbar)
+            }
             Self::TabActivate0 => Message::TabActivateJump(0),
             Self::TabActivate1 => Message::TabActivateJump(1),
             Self::TabActivate2 => Message::TabActivateJump(2),
@@ -334,6 +368,7 @@ impl Action {
             Self::TabNewNoProfile => Message::TabNewNoProfile,
             Self::TabNext => Message::TabNext,
             Self::TabPrev => Message::TabPrev,
+            Self::ToggleDropDown => Message::ToggleDropDown,
             Self::ToggleFullscreen => Message::ToggleFullscreen,
             Self::WindowClose => Message::WindowClose,
             Self::WindowNew => Message::WindowNew,
@@ -381,6 +416,7 @@ pub enum Message {
     DefaultZoomStep(usize),
     DialogMessage(Box<DialogMessage>), // DialogMessage is huge, so we use a box to make the size of this enum smaller on the stack
     Drop(Option<(pane_grid::Pane, segmented_button::Entity, DndDrop)>),
+    DropdownHeight(u32),
     Find(bool),
     FindNext,
     FindPrevious,
@@ -430,6 +466,7 @@ pub enum Message {
     ShowAdvancedFontSettings(bool),
     ShowHeaderBar(bool),
     ShowPaneBorders(bool),
+    ShowHeaderBarDropdown(bool),
     SyntaxTheme(ColorSchemeKind, usize),
     SystemThemeChange,
     TabNewInheritWorkingDirectory(bool),
@@ -444,6 +481,7 @@ pub enum Message {
     TabPrev,
     TermEvent(pane_grid::Pane, segmented_button::Entity, TermEvent),
     TermEventTx(mpsc::UnboundedSender<(pane_grid::Pane, segmented_button::Entity, TermEvent)>),
+    ToggleDropDown,
     ToggleFullscreen,
     ToggleContextPage(ContextPage),
     UpdateDefaultProfile((bool, ProfileId)),
@@ -534,6 +572,8 @@ pub struct App {
         widget::Id,
         cosmic::iced::Point,
     )>,
+    is_dropdown: bool,
+    dropdown_surface: Option<window::Id>,
     #[cfg(feature = "password_manager")]
     password_mgr: password_manager::PasswordManager,
 }
@@ -1255,7 +1295,7 @@ impl App {
                                             theme_i,
                                         )
                                     },
-                                    self.core.main_window_id().unwrap_or(window::Id::RESERVED),
+                                    self.popup_parent_id().unwrap_or(window::Id::RESERVED),
                                     Message::Surface,
                                     |a| a,
                                 ),
@@ -1514,23 +1554,48 @@ impl App {
                     .toggler(self.config.show_pane_borders, Message::ShowPaneBorders),
             );
 
-        let advanced_section = widget::settings::section()
-            .title(fl!("advanced"))
-            .add(
-                widget::settings::item::builder(fl!("show-headerbar"))
-                    .description(fl!("show-header-description"))
-                    .toggler(self.config.show_headerbar, Message::ShowHeaderBar),
-            )
-            .add(
-                widget::settings::item::builder(fl!("tab-new-inherit-working-directory"))
-                    .description(fl!("tab-new-inherit-working-directory-description"))
-                    .toggler(
-                        self.config.tab_new_inherit_working_directory,
-                        Message::TabNewInheritWorkingDirectory,
-                    ),
+        let mut dropdown_section = widget::settings::section().title(fl!("dropdown")).add(
+            widget::settings::item::builder(fl!("dropdown-height")).control(
+                widget::row::with_children(vec![
+                    // under 300, we the resize-slider is hard to access in spacious mode, so that should be the lower bound
+                    widget::slider(300..=1300, self.config.dropdown_height, |value| {
+                        Message::DropdownHeight(value)
+                    })
+                    .width(Length::Fill)
+                    .into(),
+                    widget::text(format!("{}px", self.config.dropdown_height))
+                        .width(Length::Shrink)
+                        .into(),
+                ]),
+            ),
+        );
+
+        if self.is_dropdown {
+            dropdown_section = dropdown_section.add(
+                widget::settings::item::builder(fl!("show-headerbar-dropdown")).toggler(
+                    self.config.show_headerbar_dropdown,
+                    Message::ShowHeaderBarDropdown,
+                ),
             );
+        }
+
+        let mut advanced_section = widget::settings::section().title(fl!("advanced"));
+        if !self.is_dropdown {
+            advanced_section = advanced_section.add(
+                widget::settings::item::builder(fl!("show-headerbar"))
+                    .toggler(self.config.show_headerbar, Message::ShowHeaderBar),
+            );
+        }
+        advanced_section = advanced_section.add(
+            widget::settings::item::builder(fl!("tab-new-inherit-working-directory")).toggler(
+                self.config.tab_new_inherit_working_directory,
+                Message::TabNewInheritWorkingDirectory,
+            ),
+        );
 
         widget::settings::view_column(vec![
+            // dropdown section is first, as we don't want to resize away the resize-slider
+            dropdown_section.into(),
             appearance_section.into(),
             font_section.into(),
             splits_section.into(),
@@ -1906,12 +1971,23 @@ impl Application for App {
             context_menu_popup: None,
             #[cfg(feature = "password_manager")]
             password_mgr: Default::default(),
+            is_dropdown: flags.drop_down,
+            dropdown_surface: None,
         };
 
         app.set_curr_font_weights_and_stretches();
-        let command = Task::batch([app.update_config(), app.update_title(None)]);
 
-        (app, command)
+        let mut commands = vec![app.update_config(), app.update_title(None)];
+        // on initial drop-down mode launch, if we instantly toggle the drop-down, the transparency is not yet frosted
+        // it's fine on later launches and delaying it just 1ms fixes it too
+        if app.is_dropdown {
+            commands.push(cosmic::task::future(async {
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                Message::ToggleDropDown
+            }));
+        }
+
+        (app, Task::batch(commands))
     }
 
     //TODO: currently the first escape unfocuses, and the second calls this function
@@ -2246,6 +2322,23 @@ impl Application for App {
                 if let Some(window_id) = self.core.main_window_id() {
                     return cosmic::command::toggle_maximize(window_id);
                 }
+            }
+            Message::ToggleDropDown => {
+                if !self.is_dropdown {
+                    return Task::none();
+                }
+                if let Some(id) = self.dropdown_surface.take() {
+                    // Hide the layer surface
+                    return destroy_layer_surface(id);
+                }
+                // Show the layer surface
+                let id = window::Id::unique();
+                self.dropdown_surface = Some(id);
+                return Self::create_dropdown_layer_surface(id, self.config.dropdown_height);
+            }
+            Message::DropdownHeight(height) => {
+                config_set!(dropdown_height, height);
+                return self.recreate_dropdown_surface(Some(height));
             }
             Message::CopyPrimary(entity_opt) => {
                 if let Some(tab_model) = self.pane_model.active() {
@@ -2780,7 +2873,14 @@ impl Application for App {
             Message::ShowHeaderBar(show_headerbar) => {
                 if show_headerbar != self.config.show_headerbar {
                     config_set!(show_headerbar, show_headerbar);
-                    return self.update_config();
+                    let config_task = self.update_config();
+                    return Task::batch([config_task, self.recreate_dropdown_surface(None)]);
+                }
+            }
+            Message::ShowHeaderBarDropdown(show_headerbar) => {
+                if show_headerbar != self.config.show_headerbar_dropdown {
+                    config_set!(show_headerbar_dropdown, show_headerbar);
+                    return self.recreate_dropdown_surface(None);
                 }
             }
             Message::TabNewInheritWorkingDirectory(tab_new_inherit_working_directory) => {
@@ -2876,6 +2976,9 @@ impl Application for App {
                             //Last pane, closing window
                             if let Some(window_id) = self.core.main_window_id() {
                                 return window::close(window_id);
+                            } else if self.is_dropdown {
+                                // In drop-down mode with no_main_window, exit directly
+                                std::process::exit(0);
                             }
                         }
                     }
@@ -2963,7 +3066,9 @@ impl Application for App {
 
                             #[cfg(feature = "wayland")]
                             if is_wayland() {
-                                let main_window = self.core.main_window_id().unwrap();
+                                let Some(main_window) = self.popup_parent_id() else {
+                                    return Task::none();
+                                };
                                 let pos_x = _position.x as i32;
                                 let pos_y = _position.y as i32;
 
@@ -3423,12 +3528,24 @@ impl Application for App {
     }
 
     fn view_window(&self, window_id: window::Id) -> Element<'_, Message> {
+        // Handle layer surface window for drop-down mode
+        if self.dropdown_surface == Some(window_id) {
+            return self.view();
+        }
+
+        // Handle dialog windows
         if let Some((popup_id, _pane, entity, ref link, ref autosize_id, _)) =
             self.context_menu_popup
             && window_id == popup_id
         {
             return widget::autosize::autosize(
-                menu::context_menu(&self.config, &self.key_binds, entity, link.clone()),
+                menu::context_menu(
+                    &self.config,
+                    &self.key_binds,
+                    entity,
+                    link.clone(),
+                    self.is_dropdown,
+                ),
                 autosize_id.clone(),
             )
             .into();
@@ -3552,6 +3669,7 @@ impl Application for App {
                                     &self.key_binds,
                                     popup_entity,
                                     link.clone(),
+                                    self.is_dropdown,
                                 ))
                                 .position(widget::popover::Position::Point(point));
                             popover.into()
@@ -3649,14 +3767,20 @@ impl Application for App {
         .on_drag(Message::PaneDragged);
 
         //TODO: apply window border radius xs at bottom of window
-        if show_pane_borders {
+        let mut view: Element<'_, Self::Message> = if show_pane_borders {
             // Each pane draws its own border stroke. Painting a filled
             // container behind the grid instead would stack its alpha with the
             // translucent panes and wash out the blurred backdrop.
             pane_grid.spacing(space_xxxs).into()
         } else {
             pane_grid.into()
+        };
+
+        if self.is_dropdown {
+            view = self.wrap_dropdown_view(view);
         }
+
+        view
     }
 
     fn system_theme_update(
@@ -3670,8 +3794,7 @@ impl Application for App {
     fn subscription(&self) -> Subscription<Self::Message> {
         struct ConfigSubscription;
         struct TerminalEventSubscription;
-
-        Subscription::batch([
+        let mut subscriptions = vec![
             event::listen_with(|event, _status, _window_id| match event {
                 Event::Keyboard(KeyEvent::KeyPressed {
                     key,
@@ -3724,7 +3847,13 @@ impl Application for App {
                 Some(dialog) => dialog.subscription(),
                 None => Subscription::none(),
             },
-        ])
+        ];
+
+        if self.is_dropdown {
+            subscriptions.push(self.subscribe_dropdown_signals());
+        }
+
+        Subscription::batch(subscriptions)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3505,7 +3505,7 @@ impl Application for App {
     }
 
     fn header_start(&self) -> Vec<Element<'_, Self::Message>> {
-        vec![menu_bar(&self.core, &self.config, &self.key_binds)]
+        vec![menu_bar(&self.core, &self.config, &self.key_binds, None)]
     }
 
     fn header_end(&self) -> Vec<Element<'_, Self::Message>> {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -35,6 +35,7 @@ pub fn context_menu<'a>(
     key_binds: &HashMap<KeyBind, Action>,
     entity: segmented_button::Entity,
     link: Option<String>,
+    is_drop_down: bool,
 ) -> Element<'a, Message> {
     let find_key = |action: &Action| -> String {
         for (key_bind, key_action) in key_binds {
@@ -89,14 +90,21 @@ pub fn context_menu<'a>(
             Action::PaneSplitHorizontal,
         )),
         Element::from(menu_item(fl!("split-vertical"), Action::PaneSplitVertical)),
-        Element::from(menu_item(
+    ];
+
+    if !is_drop_down {
+        rows.push(Element::from(menu_item(
             fl!("pane-toggle-maximize"),
             Action::PaneToggleMaximized,
-        )),
-        Element::from(divider::horizontal::light()),
-        Element::from(menu_item(fl!("new-tab"), Action::TabNew)),
-        Element::from(menu_item(fl!("menu-settings"), Action::Settings)),
-    ];
+        )));
+        rows.push(Element::from(divider::horizontal::light()));
+    }
+    rows.push(Element::from(menu_item(fl!("new-tab"), Action::TabNew)));
+    rows.push(Element::from(menu_item(
+        fl!("menu-settings"),
+        Action::Settings,
+    )));
+
     #[cfg(feature = "password_manager")]
     {
         rows.push(Element::from(menu_item(
@@ -104,11 +112,19 @@ pub fn context_menu<'a>(
             Action::PasswordManager,
         )));
     }
-    rows.push(Element::from(menu_checkbox(
-        fl!("show-headerbar"),
-        config.show_headerbar,
-        Action::ShowHeaderBar(!config.show_headerbar),
-    )));
+    if is_drop_down {
+        rows.push(Element::from(menu_checkbox(
+            fl!("show-headerbar-dropdown"),
+            config.show_headerbar_dropdown,
+            Action::ShowHeaderBarDropdown(!config.show_headerbar_dropdown),
+        )));
+    } else {
+        rows.push(Element::from(menu_checkbox(
+            fl!("show-headerbar"),
+            config.show_headerbar,
+            Action::ShowHeaderBar(!config.show_headerbar),
+        )));
+    }
 
     //If we have a link
     //prepend the Open Link item

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmic::iced::Point;
+use cosmic::widget::menu;
 use cosmic::widget::menu::key_bind::KeyBind;
 use cosmic::widget::menu::{Item as MenuItem, menu_button};
 use cosmic::widget::space;
@@ -12,7 +13,7 @@ use cosmic::{
     theme,
     widget::{
         self, divider,
-        menu::{ItemHeight, ItemWidth},
+        menu::{ItemHeight, ItemWidth, Tree},
         responsive_menu_bar, segmented_button,
     },
 };
@@ -215,6 +216,7 @@ pub fn menu_bar<'a>(
     core: &Core,
     config: &Config,
     key_binds: &HashMap<KeyBind, Action>,
+    parent_window_id: Option<cosmic::iced::window::Id>,
 ) -> Element<'a, Message> {
     let mut profile_items = Vec::with_capacity(config.profiles.len());
     for (name, id) in config.profile_names() {
@@ -224,86 +226,101 @@ pub fn menu_bar<'a>(
     //TODO: what to do if there are no profiles?
 
     let color_scheme_kind = config.color_scheme_kind(core.system_theme());
+    let item_width = ItemWidth::Uniform(320);
+    let item_height = ItemHeight::Dynamic(40);
+    let spacing = 4.0;
 
-    responsive_menu_bar()
-        .item_height(ItemHeight::Dynamic(40))
-        .item_width(ItemWidth::Uniform(320))
-        .spacing(4.0)
-        .into_element(
-            core,
-            key_binds,
-            MENU_ID.clone(),
-            Message::Surface,
+    let items: Vec<(String, Vec<MenuItem<Action, String>>)> = vec![
+        (
+            fl!("file"),
             vec![
-                (
-                    fl!("file"),
-                    vec![
-                        MenuItem::Button(fl!("new-tab"), None, Action::TabNew),
-                        MenuItem::Button(fl!("new-window"), None, Action::WindowNew),
-                        MenuItem::Divider,
-                        MenuItem::Folder(fl!("profile"), profile_items),
-                        MenuItem::Button(fl!("menu-profiles"), None, Action::Profiles),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("close-tab"), None, Action::TabClose),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("quit"), None, Action::WindowClose),
-                    ],
-                ),
-                (
-                    fl!("edit"),
-                    vec![
-                        MenuItem::Button(fl!("copy"), None, Action::Copy),
-                        MenuItem::Button(fl!("paste"), None, Action::Paste),
-                        MenuItem::Button(fl!("select-all"), None, Action::SelectAll),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("clear-scrollback"), None, Action::ClearScrollback),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("find"), None, Action::Find),
-                    ],
-                ),
-                (
-                    fl!("view"),
-                    vec![
-                        MenuItem::Button(fl!("zoom-in"), None, Action::ZoomIn),
-                        MenuItem::Button(fl!("zoom-reset"), None, Action::ZoomReset),
-                        MenuItem::Button(fl!("zoom-out"), None, Action::ZoomOut),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("next-tab"), None, Action::TabNext),
-                        MenuItem::Button(fl!("previous-tab"), None, Action::TabPrev),
-                        MenuItem::Divider,
-                        MenuItem::Button(
-                            fl!("split-horizontal"),
-                            None,
-                            Action::PaneSplitHorizontal,
-                        ),
-                        MenuItem::Button(fl!("split-vertical"), None, Action::PaneSplitVertical),
-                        MenuItem::Button(
-                            fl!("pane-toggle-maximize"),
-                            None,
-                            Action::PaneToggleMaximized,
-                        ),
-                        MenuItem::Divider,
-                        MenuItem::Button(
-                            fl!("menu-color-schemes"),
-                            None,
-                            Action::ColorSchemes(color_scheme_kind),
-                        ),
-                        MenuItem::Button(
-                            fl!("menu-keyboard-shortcuts"),
-                            None,
-                            Action::KeyboardShortcuts,
-                        ),
-                        MenuItem::Button(fl!("menu-settings"), None, Action::Settings),
-                        #[cfg(feature = "password_manager")]
-                        MenuItem::Button(
-                            fl!("menu-password-manager"),
-                            None,
-                            Action::PasswordManager,
-                        ),
-                        MenuItem::Divider,
-                        MenuItem::Button(fl!("menu-about"), None, Action::About),
-                    ],
-                ),
+                MenuItem::Button(fl!("new-tab"), None, Action::TabNew),
+                MenuItem::Button(fl!("new-window"), None, Action::WindowNew),
+                MenuItem::Divider,
+                MenuItem::Folder(fl!("profile"), profile_items),
+                MenuItem::Button(fl!("menu-profiles"), None, Action::Profiles),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("close-tab"), None, Action::TabClose),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("quit"), None, Action::WindowClose),
             ],
-        )
+        ),
+        (
+            fl!("edit"),
+            vec![
+                MenuItem::Button(fl!("copy"), None, Action::Copy),
+                MenuItem::Button(fl!("paste"), None, Action::Paste),
+                MenuItem::Button(fl!("select-all"), None, Action::SelectAll),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("clear-scrollback"), None, Action::ClearScrollback),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("find"), None, Action::Find),
+            ],
+        ),
+        (
+            fl!("view"),
+            vec![
+                MenuItem::Button(fl!("zoom-in"), None, Action::ZoomIn),
+                MenuItem::Button(fl!("zoom-reset"), None, Action::ZoomReset),
+                MenuItem::Button(fl!("zoom-out"), None, Action::ZoomOut),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("next-tab"), None, Action::TabNext),
+                MenuItem::Button(fl!("previous-tab"), None, Action::TabPrev),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("split-horizontal"), None, Action::PaneSplitHorizontal),
+                MenuItem::Button(fl!("split-vertical"), None, Action::PaneSplitVertical),
+                MenuItem::Button(
+                    fl!("pane-toggle-maximize"),
+                    None,
+                    Action::PaneToggleMaximized,
+                ),
+                MenuItem::Divider,
+                MenuItem::Button(
+                    fl!("menu-color-schemes"),
+                    None,
+                    Action::ColorSchemes(color_scheme_kind),
+                ),
+                MenuItem::Button(
+                    fl!("menu-keyboard-shortcuts"),
+                    None,
+                    Action::KeyboardShortcuts,
+                ),
+                MenuItem::Button(fl!("menu-settings"), None, Action::Settings),
+                #[cfg(feature = "password_manager")]
+                MenuItem::Button(fl!("menu-password-manager"), None, Action::PasswordManager),
+                MenuItem::Divider,
+                MenuItem::Button(fl!("menu-about"), None, Action::About),
+            ],
+        ),
+    ];
+
+    if let Some(parent_id) = parent_window_id {
+        // Layer surface / --drop-down mode: must use menu::bar directly with explicit parent.
+        // responsive_menu_bar's into_element hardcodes core.main_window_id() = None
+        // in no_main_window / --drop-down mode.
+        let trees: Vec<Tree<Message>> = items
+            .into_iter()
+            .map(|(label, items)| {
+                Tree::<_>::with_children(
+                    Element::from(menu::root(label)),
+                    menu::items(key_binds, items),
+                )
+            })
+            .collect();
+
+        menu::bar(trees)
+            .item_width(item_width)
+            .item_height(item_height)
+            .spacing(spacing)
+            .on_surface_action(Message::Surface)
+            .window_id(parent_id)
+            .into()
+    } else {
+        // Regular window: use responsive_menu_bar (handles collapse on narrow bars).
+        responsive_menu_bar()
+            .item_height(item_height)
+            .item_width(item_width)
+            .spacing(spacing)
+            .into_element(core, key_binds, MENU_ID.clone(), Message::Surface, items)
+    }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -196,7 +196,7 @@ impl TerminalPaneGrid {
         }
     }
     pub fn unfocus_all_terminals(&self) {
-        for (_pane, tab_model) in self.panes.panes.iter() {
+        for tab_model in self.panes.panes.values() {
             let entity = tab_model.active();
             if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
                 let mut terminal = terminal.lock().unwrap();

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -543,7 +543,7 @@ where
                     fn fill<Renderer: renderer::Renderer>(
                         &mut self,
                         renderer: &mut Renderer,
-                        is_focused: bool,
+                        _is_focused: bool,
                     ) {
                         let cosmic_text_to_iced_color = |color: cosmic_text::Color| {
                             Color::from_rgba(


### PR DESCRIPTION
* Add --drop-down CLI flag, that adds new behavior and keeps all the old behavior if not used
* Behavior on first launch: create a surface, add a signal handler, render the terminal into that overlay surface
* Behavior on later launches: find the process that was launched with "--drop-down" and send a signal to it (currently via spawning a process) Handle USR1 signals for toggling dropdown
* Custom right click context menu in dropdown mode, as maximizing makes no sense
* Added setting: A secondary show-headers-dropdown that's only visible in drop down mode
* Added setting: The height of the dropdown in px, I'd like to do relative but to my understanding wayland doesn't trivially allow that
* Bug byepass in iced: When creating the overlay without any delay, the window is transparent but not "frosted"

This is hugely based on pop-os#673 and just rebased and refactored, as various menu things like the header and the context menu were broken for me, and the pid file thing was overly complicated and introduced too many dependencies.

I think this MR is relevant, because people are already vibe coding a non-working version of this: https://github.com/M0Rf30/cosmic-ext-quake-terminal

Here is a screenshot of how it looks for me:
<img width="1920" height="1080" alt="Screenshot_2026-07-22_11-44-40" src="https://github.com/user-attachments/assets/20c53d4e-e825-4009-8917-7e5f4a25dcfd" />

And here one without header + with settings open:
<img width="1920" height="1080" alt="Screenshot_2026-07-22_12-11-27" src="https://github.com/user-attachments/assets/f3e580b8-2e00-45d4-a5b5-e566882767a4" />



This was partially created with the help of AI.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

