### PR TITLE
feat: add shortcut action to close split pane (fixes #868)

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -69,6 +69,7 @@ tab-new-inherit-working-directory-description = Open new tabs and windows in the
 ### Keyboard shortcuts
 add-another-keybinding = Add another keybinding
 cancel = Cancel
+pane-close = Close split pane
 close-window = Close window
 copy-or-sigint = Copy or SIGINT
 disable = Disable

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,7 @@ pub enum Action {
     PaneSplitHorizontal,
     PaneSplitVertical,
     PaneToggleMaximized,
+    PaneClose,
     Paste,
     PastePrimary,
     ProfileOpen(ProfileId),
@@ -311,6 +312,7 @@ impl Action {
             Self::PaneSplitHorizontal => Message::PaneSplit(pane_grid::Axis::Horizontal),
             Self::PaneSplitVertical => Message::PaneSplit(pane_grid::Axis::Vertical),
             Self::PaneToggleMaximized => Message::PaneToggleMaximized,
+            Self::PaneClose => Message::PaneClose,
             #[cfg(feature = "password_manager")]
             Self::PasswordManager => Message::ToggleContextPage(ContextPage::PasswordManager),
             Self::Paste => Message::Paste(entity_opt),
@@ -405,6 +407,7 @@ pub enum Message {
     PaneFocusAdjacent(pane_grid::Direction),
     PaneResized(pane_grid::ResizeEvent),
     PaneSplit(pane_grid::Axis),
+    PaneClose,
     PaneToggleMaximized,
     #[cfg(feature = "password_manager")]
     PasswordManager(password_manager::PasswordManagerMessage),
@@ -2606,6 +2609,21 @@ impl Application for App {
                     self.pane_model.panes.maximize(self.pane_model.focused());
                 }
                 return self.update_focus();
+            }
+            Message::PaneClose => {
+                let pane = self.pane_model.focused();
+
+                // closes current pane, if no sibling was returned, closes the window
+                if let Some((_, sibling)) = self.pane_model.panes.close(pane) {
+                    self.terminal_ids.remove(&pane);
+                    self.pane_model.set_focus(sibling);
+
+                    return self.update_title(Some(sibling));
+                } else {
+                    if let Some(window_id) = self.core.main_window_id() {
+                        return window::close(window_id);
+                    }
+                }
             }
             Message::PaneFocusAdjacent(direction) => {
                 if let Some(adjacent) = self

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -68,6 +68,7 @@ pub enum KeyBindAction {
     PaneSplitHorizontal,
     PaneSplitVertical,
     PaneToggleMaximized,
+    PaneClose,
     Paste,
     PastePrimary,
     #[cfg_attr(not(feature = "password_manager"), allow(dead_code))]
@@ -110,6 +111,7 @@ impl KeyBindAction {
             Self::PaneSplitHorizontal => Some(Action::PaneSplitHorizontal),
             Self::PaneSplitVertical => Some(Action::PaneSplitVertical),
             Self::PaneToggleMaximized => Some(Action::PaneToggleMaximized),
+            Self::PaneClose => Some(Action::PaneClose),
             Self::Paste => Some(Action::Paste),
             Self::PastePrimary => Some(Action::PastePrimary),
             Self::SelectAll => Some(Action::SelectAll),
@@ -270,6 +272,7 @@ pub fn action_label(action: KeyBindAction) -> String {
         KeyBindAction::PaneSplitHorizontal => fl!("split-horizontal"),
         KeyBindAction::PaneSplitVertical => fl!("split-vertical"),
         KeyBindAction::PaneToggleMaximized => fl!("pane-toggle-maximize"),
+        KeyBindAction::PaneClose => fl!("pane-close"),
         KeyBindAction::Paste => fl!("paste"),
         KeyBindAction::PastePrimary => fl!("paste-primary"),
         KeyBindAction::PasswordManager => fl!("password-manager"),
@@ -339,6 +342,7 @@ pub fn shortcut_groups() -> Vec<ShortcutGroup> {
             KeyBindAction::PaneSplitHorizontal,
             KeyBindAction::PaneSplitVertical,
             KeyBindAction::PaneToggleMaximized,
+            KeyBindAction::PaneClose,
             KeyBindAction::PaneFocusLeft,
             KeyBindAction::PaneFocusRight,
             KeyBindAction::PaneFocusUp,
@@ -462,6 +466,7 @@ fn fallback_shortcuts() -> Shortcuts {
     bind!([Ctrl, Alt], "d", PaneSplitHorizontal);
     bind!([Ctrl, Alt], "r", PaneSplitVertical);
     bind!([Ctrl, Shift], "X", PaneToggleMaximized);
+    bind!([Ctrl, Alt], "w", PaneClose);
     #[cfg(feature = "password_manager")]
     bind!([Ctrl, Alt], "p", PasswordManager);
 


### PR DESCRIPTION
Adds a keyboard shortcut to close the current focused pane. The shortcut is Ctrl + Alt + W

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

