### PR TITLE
Adjustable translucensy

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@
 
 use cosmic::{
     cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry},
+    cosmic_theme::BlurStrength,
     theme,
 };
 use cosmic_text::{Metrics, Stretch, Weight};
@@ -16,6 +17,10 @@ use crate::{fl, localize::LANGUAGE_SORTER, shortcuts::Shortcuts};
 pub const CONFIG_VERSION: u64 = 1;
 pub const COSMIC_THEME_DARK: &str = "COSMIC Dark";
 pub const COSMIC_THEME_LIGHT: &str = "COSMIC Light";
+
+/// Highest position on the frosted glass opacity slider, one step per
+/// [`BlurStrength`].
+pub const MAX_BLUR_POSITION: u8 = BlurStrength::ExtremelyHigh2 as u8;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum AppTheme {
@@ -216,7 +221,7 @@ impl Default for Profile {
     }
 }
 
-#[derive(Clone, CosmicConfigEntry, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, CosmicConfigEntry, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Config {
     pub app_theme: AppTheme,
     pub color_schemes_dark: BTreeMap<ColorSchemeId, ColorScheme>,
@@ -229,6 +234,10 @@ pub struct Config {
     pub font_stretch: u16,
     pub font_size_zoom_step_mul_100: u16,
     pub opacity: u8,
+    /// Opacity under the compositor's frosted glass effect, kept separate from
+    /// [`Self::opacity`] because it is a level in the theme's alpha map rather
+    /// than an absolute percentage.
+    pub blur_opacity: BlurStrength,
     pub profiles: BTreeMap<ProfileId, Profile>,
     pub show_headerbar: bool,
     pub show_pane_borders: bool,
@@ -259,6 +268,7 @@ impl Default for Config {
             font_stretch: Stretch::Normal.to_number(),
             font_weight: Weight::NORMAL.0,
             opacity: 100,
+            blur_opacity: BlurStrength::VeryLow,
             profiles: BTreeMap::new(),
             show_headerbar: true,
             show_pane_borders: false,
@@ -347,6 +357,26 @@ impl Config {
         f32::from(self.opacity) / 100.0
     }
 
+    /// Background opacity under the compositor's frosted glass effect. Resolved
+    /// against the theme rather than stored, so it follows the system-wide blur
+    /// settings; both lookups are plain matches on borrowed data, cheap enough
+    /// to call while rendering.
+    pub fn blur_opacity_ratio(&self, theme: &theme::Theme) -> f32 {
+        theme.cosmic().alpha_map.blurred_alpha(self.blur_opacity)
+    }
+
+    /// Position of [`Self::blur_opacity`] on the settings slider. Blur strength
+    /// grows as opacity falls, so the positions are reversed to let the slider
+    /// run in the same direction as the plain opacity one.
+    pub fn blur_opacity_position(&self) -> u8 {
+        MAX_BLUR_POSITION - self.blur_opacity as u8
+    }
+
+    /// Inverse of [`Self::blur_opacity_position`].
+    pub fn blur_strength_at(position: u8) -> BlurStrength {
+        BlurStrength::try_from(MAX_BLUR_POSITION.saturating_sub(position)).unwrap_or_default()
+    }
+
     // Get a sorted and adjusted for duplicates list of profile names and ids
     pub fn profile_names(&self) -> Vec<(String, ProfileId)> {
         let mut profile_names = Vec::<(String, ProfileId)>::with_capacity(self.profiles.len());
@@ -402,5 +432,65 @@ impl Config {
                 Normal, SemiExpanded, Expanded, ExtraExpanded, UltraExpanded,
             }
         })[&self.font_stretch]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slider_position_round_trips_through_every_blur_strength() {
+        for position in 0..=MAX_BLUR_POSITION {
+            let config = Config {
+                blur_opacity: Config::blur_strength_at(position),
+                ..Config::default()
+            };
+            assert_eq!(config.blur_opacity_position(), position);
+        }
+    }
+
+    /// The slider has to run the same direction as the plain opacity one, even
+    /// though a higher blur strength means a lower alpha.
+    #[test]
+    fn a_higher_slider_position_is_more_opaque() {
+        let theme = theme::Theme::dark();
+        let ratio = |position| {
+            Config {
+                blur_opacity: Config::blur_strength_at(position),
+                ..Config::default()
+            }
+            .blur_opacity_ratio(&theme)
+        };
+
+        for position in 1..=MAX_BLUR_POSITION {
+            assert!(
+                ratio(position) > ratio(position - 1),
+                "position {position} is not more opaque than {}",
+                position - 1
+            );
+        }
+    }
+
+    /// Translucent, but more opaque than what the theme uses for its own
+    /// frosted containers: that alpha is tuned for containers behind other
+    /// content, and terminal text has to stay readable on top of it.
+    #[test]
+    fn default_blur_opacity_sits_above_the_theme_frosted_alpha() {
+        let theme = theme::Theme::dark();
+        let cosmic = theme.cosmic();
+        let default = Config::default().blur_opacity_ratio(&theme);
+
+        assert!(default < 1.0, "{default} is not translucent");
+        assert!(default > cosmic.alpha_map.blurred_alpha(cosmic.frosted));
+    }
+
+    #[test]
+    fn opacity_ratio_follows_the_configured_percentage() {
+        let config = Config {
+            opacity: 75,
+            ..Config::default()
+        };
+        assert!((config.opacity_ratio() - 0.75).abs() < f32::EPSILON);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,8 @@ use std::{
 use tokio::sync::mpsc;
 
 use config::{
-    AppTheme, CONFIG_VERSION, ColorScheme, ColorSchemeId, ColorSchemeKind, Config, Profile,
-    ProfileId,
+    AppTheme, CONFIG_VERSION, ColorScheme, ColorSchemeId, ColorSchemeKind, Config,
+    MAX_BLUR_POSITION, Profile, ProfileId,
 };
 mod config;
 mod mouse_reporter;
@@ -356,6 +356,7 @@ impl MenuAction for Action {
 #[derive(Clone, Debug)]
 pub enum Message {
     AppTheme(AppTheme),
+    BlurOpacity(u8),
     ClearScrollback(Option<segmented_button::Entity>),
     ColorSchemeCollapse,
     ColorSchemeDelete(ColorSchemeKind, ColorSchemeId),
@@ -1417,6 +1418,16 @@ impl App {
                     .control(widget::slider(0..=100, self.config.opacity, |opacity| {
                         Message::Opacity(opacity)
                     }))
+            }))
+            // Under frosted glass the opacity is a level in the theme's alpha
+            // map rather than a percentage, so the slider steps through those
+            // and carries no value label.
+            .add_maybe(t.transparent.then(|| {
+                widget::settings::item::builder(fl!("opacity")).control(widget::slider(
+                    0..=MAX_BLUR_POSITION,
+                    self.config.blur_opacity_position(),
+                    Message::BlurOpacity,
+                ))
             }));
 
         let mut font_section = widget::settings::section()
@@ -1980,6 +1991,9 @@ impl Application for App {
             Message::AppTheme(app_theme) => {
                 config_set!(app_theme, app_theme);
                 return self.update_config();
+            }
+            Message::BlurOpacity(position) => {
+                config_set!(blur_opacity, Config::blur_strength_at(position));
             }
             Message::ClearScrollback(entity_opt) => {
                 if let Some(tab_model) = self.pane_model.active() {
@@ -3507,7 +3521,7 @@ impl Application for App {
                     .on_window_focused(|| Message::WindowFocused)
                     .on_window_unfocused(|| Message::WindowUnfocused)
                     .opacity(if t.transparent {
-                        t.cosmic().alpha_map.blurred_alpha(t.cosmic().frosted)
+                        self.config.blur_opacity_ratio(t)
                     } else {
                         self.config.opacity_ratio()
                     })

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -446,6 +446,7 @@ where
             // Pane too small for content, but still fill background
             let terminal = self.terminal.lock().unwrap();
             let meta = &terminal.metadata_set[terminal.default_attrs().metadata];
+            let background_color = shade(meta.bg, state.is_focused && !self.disabled);
             renderer.fill_quad(
                 Quad {
                     bounds: layout.bounds(),
@@ -458,12 +459,12 @@ where
                     ..Default::default()
                 },
                 Color::from_rgba(
-                    f32::from(meta.bg.r()) / 255.0,
-                    f32::from(meta.bg.g()) / 255.0,
-                    f32::from(meta.bg.b()) / 255.0,
+                    f32::from(background_color.r()) / 255.0,
+                    f32::from(background_color.g()) / 255.0,
+                    f32::from(background_color.b()) / 255.0,
                     match self.opacity {
                         Some(opacity) => opacity,
-                        None => f32::from(meta.bg.a()) / 255.0,
+                        None => f32::from(background_color.a()) / 255.0,
                     },
                 ),
             );
@@ -484,6 +485,8 @@ where
         // Render default background
         {
             let meta = &terminal.metadata_set[terminal.default_attrs().metadata];
+            let background_color = shade(meta.bg, state.is_focused && !self.disabled);
+
             renderer.fill_quad(
                 Quad {
                     bounds: layout.bounds(),
@@ -496,12 +499,12 @@ where
                     ..Default::default()
                 },
                 Color::from_rgba(
-                    f32::from(meta.bg.r()) / 255.0,
-                    f32::from(meta.bg.g()) / 255.0,
-                    f32::from(meta.bg.b()) / 255.0,
+                    f32::from(background_color.r()) / 255.0,
+                    f32::from(background_color.g()) / 255.0,
+                    f32::from(background_color.b()) / 255.0,
                     match self.opacity {
                         Some(opacity) => opacity,
-                        None => f32::from(meta.bg.a()) / 255.0,
+                        None => f32::from(background_color.a()) / 255.0,
                     },
                 ),
             );
@@ -543,7 +546,7 @@ where
                     fn fill<Renderer: renderer::Renderer>(
                         &mut self,
                         renderer: &mut Renderer,
-                        _is_focused: bool,
+                        is_focused: bool,
                     ) {
                         let cosmic_text_to_iced_color = |color: cosmic_text::Color| {
                             Color::from_rgba(
@@ -584,9 +587,10 @@ where
 
                         let metadata = &self.metadata_set[self.metadata];
                         if metadata.bg != self.metadata_set[self.default_metadata].bg {
+                            let color = shade(metadata.bg, is_focused);
                             renderer.fill_quad(
                                 mk_quad!(mk_pos_offset!(0.0, self.line_height), self.line_height),
-                                cosmic_text_to_iced_color(metadata.bg),
+                                cosmic_text_to_iced_color(color),
                             );
                         }
 
@@ -1763,6 +1767,20 @@ fn accumulate_wheel_lines(y: f32, accumulator: f32) -> (i32, f32) {
     let total = accumulator + y * SCROLL_LINE_MULTIPLIER;
     let lines = total.trunc() as i32;
     (lines, total - lines as f32)
+}
+
+fn shade(color: cosmic_text::Color, is_focused: bool) -> cosmic_text::Color {
+    if is_focused {
+        color
+    } else {
+        let shade = 0.92;
+        cosmic_text::Color::rgba(
+            (f32::from(color.r()) * shade) as u8,
+            (f32::from(color.g()) * shade) as u8,
+            (f32::from(color.b()) * shade) as u8,
+            color.a(),
+        )
+    }
 }
 
 impl<'a, Message> From<TerminalBox<'a, Message>> for Element<'a, Message, cosmic::Theme, Renderer>


### PR DESCRIPTION
I have, with the help of Claude Code, made a fix for #878 . Now the opacity configuration is now shown for frosted glass effect, but defaults to the opacity value for the Primary layer and not the Background layer which it was previously. I think Primary might be a bit low, but it is a lot better than using the same as the Background layer. I also restored the non-focus tint. 


- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

