### PR TITLE
fix: round subpixel coordinates for glyph background rectangles

### DIFF
--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -557,7 +557,7 @@ where
                         macro_rules! mk_pos_offset {
                             ($x_offset:expr, $bottom_offset:expr) => {
                                 Vector::new(
-                                    self.start_x + $x_offset,
+                                    (self.start_x + $x_offset).floor(),
                                     self.line_top + self.line_height - $bottom_offset,
                                 )
                             };
@@ -574,7 +574,11 @@ where
                                 }
                             };
                             ($pos_offset:expr, $style_line_height:expr) => {
-                                mk_quad!($pos_offset, $style_line_height, self.end_x - self.start_x)
+                                mk_quad!(
+                                    $pos_offset,
+                                    $style_line_height,
+                                    (self.end_x - self.start_x).ceil()
+                                )
                             };
                         }
 


### PR DESCRIPTION
`cosmic-term` currently has an issue where borders appear to separate some cells columnwise. This was caused due to the accumulation of floating point error when using font sizes that can't be fully represented in an f32. For example, a font size of 8.4x20 and a unique color per cell is enough to reproduce this. Essentially, the glyph background rectangles are being drawn slightly too narrow, causing the terminal background to leak through. This patch rounds the rectangles in such a way that we guarantee the drawing of that "border" pixel using floor() and ceil().

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

