### PR TITLE
feat: add confirm on close setting and dialog

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -66,6 +66,10 @@ show-headerbar = Show header
 show-header-description = Reveal the header from the right-click menu
 tab-new-inherit-working-directory = New tabs and windows use current directory
 tab-new-inherit-working-directory-description = Open new tabs and windows in the active tab's working directory
+confirm-on-close = Confirm before closing
+confirm-on-close-description = Ask for confirmation before closing the terminal window
+confirm-close-title = Close Terminal?
+confirm-close-body = Are you sure you want to close this terminal? Any running processes will be terminated.
 
 ### Keyboard shortcuts
 add-another-keybinding = Add another keybinding

--- a/i18n/es-419/cosmic_term.ftl
+++ b/i18n/es-419/cosmic_term.ftl
@@ -70,6 +70,10 @@ show-headerbar = Mostrar encabezado
 show-header-description = Mostrar el encabezado desde el menú contextual.
 tab-new-inherit-working-directory = Las pestañas nuevas usan el directorio actual
 tab-new-inherit-working-directory-description = Abrir pestañas nuevas en el directorio de trabajo de la pestaña activa
+confirm-on-close = Confirmar antes de cerrar
+confirm-on-close-description = Pedir confirmación antes de cerrar la ventana de la terminal
+confirm-close-title = ¿Cerrar terminal?
+confirm-close-body = ¿Estás seguro de que deseas cerrar esta terminal? Los procesos en ejecución se detendrán.
 # Find
 find-placeholder = Buscar...
 find-previous = Buscar anterior

--- a/i18n/es-ES/cosmic_term.ftl
+++ b/i18n/es-ES/cosmic_term.ftl
@@ -69,9 +69,13 @@ focus-follow-mouse = Enfoque del tecleo sigue el ratón
 
 advanced = Avanzado
 show-headerbar = Mostrar encabezado
-show-header-description = Mostrar encabezado desde el menú del clic secundario.
+show-header-description = Mostrar el encabezado desde el menú contextual.
 tab-new-inherit-working-directory = Las pestañas nuevas usan el directorio actual
 tab-new-inherit-working-directory-description = Abrir pestañas nuevas en el directorio de trabajo de la pestaña activa
+confirm-on-close = Confirmar antes de cerrar
+confirm-on-close-description = Pedir confirmación antes de cerrar la ventana de la terminal
+confirm-close-title = ¿Cerrar terminal?
+confirm-close-body = ¿Estás seguro de que deseas cerrar esta terminal? Los procesos en ejecución se detendrán.
 # Find
 find-placeholder = Buscar...
 find-previous = Buscar previo

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,8 @@ pub struct Config {
     pub focus_follow_mouse: bool,
     #[serde(default)]
     pub tab_new_inherit_working_directory: bool,
+    #[serde(default)]
+    pub confirm_on_close: bool,
     pub default_profile: Option<ProfileId>,
     #[serde(default)]
     pub shortcuts_custom: Shortcuts,
@@ -253,6 +255,7 @@ impl Default for Config {
             dim_font_weight: Weight::NORMAL.0,
             focus_follow_mouse: false,
             tab_new_inherit_working_directory: false,
+            confirm_on_close: false,
             font_name: "Noto Sans Mono".to_string(),
             font_size: 14,
             font_size_zoom_step_mul_100: 100,

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,9 @@ pub enum Message {
     ColorSchemeRenameSubmit,
     ColorSchemeTabActivate(widget::segmented_button::Entity),
     Config(Box<Config>),
+    ConfirmOnClose(bool),
+    ConfirmCloseConfirmed,
+    ConfirmCloseCanceled,
     Copy(Option<segmented_button::Entity>),
     CopyOrSigint(Option<segmented_button::Entity>),
     CopyPrimary(Option<segmented_button::Entity>),
@@ -525,6 +528,7 @@ pub struct App {
     shortcut_search_id: widget::Id,
     shortcut_search_regex: Option<regex::Regex>,
     shortcut_search_value: String,
+    show_confirm_close_dialog: bool,
     modifiers: Modifiers,
     context_menu_popup: Option<(
         window::Id,
@@ -1528,6 +1532,14 @@ impl App {
                         self.config.tab_new_inherit_working_directory,
                         Message::TabNewInheritWorkingDirectory,
                     ),
+            )
+            .add(
+                widget::settings::item::builder(fl!("confirm-on-close"))
+                    .description(fl!("confirm-on-close-description"))
+                    .toggler(
+                        self.config.confirm_on_close,
+                        Message::ConfirmOnClose,
+                    ),
             );
 
         widget::settings::view_column(vec![
@@ -1902,6 +1914,7 @@ impl Application for App {
             shortcut_search_id: widget::Id::unique(),
             shortcut_search_regex: None,
             shortcut_search_value: String::new(),
+            show_confirm_close_dialog: false,
             modifiers: Modifiers::empty(),
             context_menu_popup: None,
             #[cfg(feature = "password_manager")]
@@ -1916,6 +1929,11 @@ impl Application for App {
 
     //TODO: currently the first escape unfocuses, and the second calls this function
     fn on_escape(&mut self) -> Task<Message> {
+        if self.show_confirm_close_dialog {
+            self.show_confirm_close_dialog = false;
+            return Task::none();
+        }
+
         if self.core.window.show_context {
             // Handle keyboard shortcut page escape
             if let ContextPage::KeyboardShortcuts = self.context_page {
@@ -2789,6 +2807,20 @@ impl Application for App {
                     tab_new_inherit_working_directory
                 );
             }
+            Message::ConfirmOnClose(confirm_on_close) => {
+                if confirm_on_close != self.config.confirm_on_close {
+                    config_set!(confirm_on_close, confirm_on_close);
+                }
+            }
+            Message::ConfirmCloseConfirmed => {
+                self.show_confirm_close_dialog = false;
+                if let Some(window_id) = self.core.main_window_id() {
+                    return window::close(window_id);
+                }
+            }
+            Message::ConfirmCloseCanceled => {
+                self.show_confirm_close_dialog = false;
+            }
             Message::ShowPaneBorders(show_pane_borders) => {
                 if show_pane_borders != self.config.show_pane_borders {
                     config_set!(show_pane_borders, show_pane_borders);
@@ -3248,6 +3280,10 @@ impl Application for App {
                 config_set!(default_profile, default.then_some(profile_id));
             }
             Message::WindowClose => {
+                if self.config.confirm_on_close {
+                    self.show_confirm_close_dialog = true;
+                    return Task::none();
+                }
                 if let Some(window_id) = self.core.main_window_id() {
                     return window::close(window_id);
                 }
@@ -3372,6 +3408,23 @@ impl Application for App {
     }
 
     fn dialog(&self) -> Option<Element<'_, Message>> {
+        if self.show_confirm_close_dialog {
+            return Some(
+                widget::dialog()
+                    .title(fl!("confirm-close-title"))
+                    .body(fl!("confirm-close-body"))
+                    .primary_action(
+                        widget::button::destructive(fl!("close-window"))
+                            .on_press(Message::ConfirmCloseConfirmed),
+                    )
+                    .secondary_action(
+                        widget::button::standard(fl!("cancel"))
+                            .on_press(Message::ConfirmCloseCanceled),
+                    )
+                    .into(),
+            );
+        }
+
         let conflict = self.shortcut_conflict.as_ref()?;
         let binding = shortcuts::binding_display(&conflict.binding);
         let existing = shortcuts::action_label(conflict.existing_action);
@@ -3418,6 +3471,9 @@ impl Application for App {
             && id == *popup_id
         {
             return Some(Message::ContextMenuPopupClosed(id));
+        }
+        if self.core.main_window_id() == Some(id) {
+            return Some(Message::WindowClose);
         }
         None
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut settings = Settings::default();
     settings = settings.theme(config.app_theme.theme());
     settings = settings.size_limits(Limits::NONE.min_width(360.0).min_height(180.0));
+    settings = settings.exit_on_close(false);
 
     // Flags
     let flags = Flags {
@@ -452,6 +453,7 @@ pub enum Message {
     UpdateDefaultProfile((bool, ProfileId)),
     UseBrightBold(bool),
     WindowClose,
+    WindowCloseRequested(window::Id),
     WindowNew,
     WindowFocused,
     WindowUnfocused,
@@ -1550,6 +1552,18 @@ impl App {
         ])
         .into()
     }
+
+    fn request_close_window(&mut self) -> Task<Message> {
+        if self.config.confirm_on_close {
+            self.show_confirm_close_dialog = true;
+            Task::none()
+        } else if let Some(window_id) = self.core.main_window_id() {
+            window::close(window_id)
+        } else {
+            Task::none()
+        }
+    }
+
     fn get_default_profile(&self) -> Option<ProfileId> {
         self.config.default_profile
     }
@@ -2905,10 +2919,8 @@ impl Application for App {
                             self.terminal_ids.remove(&self.pane_model.focused());
                             self.pane_model.set_focus(sibling);
                         } else {
-                            //Last pane, closing window
-                            if let Some(window_id) = self.core.main_window_id() {
-                                return window::close(window_id);
-                            }
+                            // Last pane, closing window
+                            return self.request_close_window();
                         }
                     }
                 }
@@ -3280,13 +3292,13 @@ impl Application for App {
                 config_set!(default_profile, default.then_some(profile_id));
             }
             Message::WindowClose => {
-                if self.config.confirm_on_close {
-                    self.show_confirm_close_dialog = true;
-                    return Task::none();
+                return self.request_close_window();
+            }
+            Message::WindowCloseRequested(id) => {
+                if self.core.main_window_id() == Some(id) {
+                    return self.request_close_window();
                 }
-                if let Some(window_id) = self.core.main_window_id() {
-                    return window::close(window_id);
-                }
+                return Task::none();
             }
             Message::WindowNew => match env::current_exe() {
                 Ok(exe) => {
@@ -3466,6 +3478,10 @@ impl Application for App {
         ]
     }
 
+    fn on_app_exit(&mut self) -> Option<Self::Message> {
+        Some(Message::WindowClose)
+    }
+
     fn on_close_requested(&self, id: window::Id) -> Option<Self::Message> {
         if let Some((popup_id, _, _, _, _, _)) = &self.context_menu_popup
             && id == *popup_id
@@ -3473,7 +3489,7 @@ impl Application for App {
             return Some(Message::ContextMenuPopupClosed(id));
         }
         if self.core.main_window_id() == Some(id) {
-            return Some(Message::WindowClose);
+            return Some(Message::WindowCloseRequested(id));
         }
         None
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3867,4 +3867,20 @@ mod tests {
             color.alpha
         );
     }
+
+    #[test]
+    fn config_confirm_on_close_defaults_to_false() {
+        let config = crate::config::Config::default();
+        assert!(!config.confirm_on_close);
+    }
+
+    #[test]
+    fn config_confirm_on_close_serde() {
+        let mut config = crate::config::Config::default();
+        config.confirm_on_close = true;
+        let serialized = ron::to_string(&config).expect("failed to serialize");
+        let deserialized: crate::config::Config =
+            ron::from_str(&serialized).expect("failed to deserialize");
+        assert!(deserialized.confirm_on_close);
+    }
 }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -543,7 +543,7 @@ where
                     fn fill<Renderer: renderer::Renderer>(
                         &mut self,
                         renderer: &mut Renderer,
-                        is_focused: bool,
+                        _is_focused: bool,
                     ) {
                         let cosmic_text_to_iced_color = |color: cosmic_text::Color| {
                             Color::from_rgba(


### PR DESCRIPTION
## Summary
    This PR adds a configurable setting to ask for confirmation before closing the terminal window (disabled by default), preventing accidental exits.

    ## Changes
    - **Configuration**: Added `confirm_on_close: bool` (default `false`) in `src/config.rs`.
    - **Settings UI**: Added toggle in Settings > Advanced.
    - **Unified Close Handling**: Native dialog shown when closing via:
      - Headerbar close button `(X)` (handled cleanly through `on_app_exit`).
      - Menu item `File > Quit`.
      - Shortcuts `Ctrl + Shift + Q` (WindowClose) and `Ctrl + Shift + W` (when closing the last remaining tab).
    - **Internationalization (i18n)**: Added Fluent translations for `en`, `es-419`, and `es-ES`.
    - **Unit Tests**: Added unit tests in `src/main.rs` for default config and serde roundtrip.
    - 
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

