### PR TITLE
feat: Make hardcoded Shift+Page(Up|Down) and Shift+(Home|End) configurable

### DIFF
--- a/i18n/en/cosmic_term.ftl
+++ b/i18n/en/cosmic_term.ftl
@@ -119,6 +119,10 @@ paste = Paste
 select-all = Select all
 find = Find
 clear-scrollback = Clear scrollback
+scroll-to-top = Scroll to top
+scroll-to-bottom = Scroll to bottom
+scroll-page-up = Scroll page up
+scroll-page-down = Scroll page down
 
 ## Open
 open-link = Open Link

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,10 @@ pub enum Action {
     ZoomIn,
     ZoomOut,
     ZoomReset,
+    ScrollToTop,
+    ScrollToBottom,
+    ScrollPageUp,
+    ScrollPageDown,
 }
 
 impl Action {
@@ -340,6 +344,10 @@ impl Action {
             Self::ZoomIn => Message::ZoomIn,
             Self::ZoomOut => Message::ZoomOut,
             Self::ZoomReset => Message::ZoomReset,
+            Self::ScrollToTop => Message::ScrollTerminal(TerminalScroll::Top, entity_opt),
+            Self::ScrollToBottom => Message::ScrollTerminal(TerminalScroll::Bottom, entity_opt),
+            Self::ScrollPageUp => Message::ScrollTerminal(TerminalScroll::PageUp, entity_opt),
+            Self::ScrollPageDown => Message::ScrollTerminal(TerminalScroll::PageDown, entity_opt),
         }
     }
 }
@@ -426,6 +434,7 @@ pub enum Message {
     ProfileTabTitle(ProfileId, String),
     ReorderTab(Pane, ReorderEvent),
     Surface(surface::Action),
+    ScrollTerminal(TerminalScroll, Option<segmented_button::Entity>),
     SelectAll(Option<segmented_button::Entity>),
     ShowAdvancedFontSettings(bool),
     ShowHeaderBar(bool),
@@ -1988,6 +1997,15 @@ impl Application for App {
                         let terminal = terminal.lock().unwrap();
                         let mut term = terminal.term.lock();
                         term.grid_mut().clear_history();
+                    }
+                }
+            }
+            Message::ScrollTerminal(scroll, entity_opt) => {
+                if let Some(tab_model) = self.pane_model.active() {
+                    let entity = entity_opt.unwrap_or_else(|| tab_model.active());
+                    if let Some(terminal) = tab_model.data::<Mutex<Terminal>>(entity) {
+                        let terminal = terminal.lock().unwrap();
+                        terminal.scroll(scroll);
                     }
                 }
             }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -93,6 +93,10 @@ pub enum KeyBindAction {
     ZoomIn,
     ZoomOut,
     ZoomReset,
+    ScrollToTop,
+    ScrollToBottom,
+    ScrollPageUp,
+    ScrollPageDown,
 }
 
 impl KeyBindAction {
@@ -133,6 +137,10 @@ impl KeyBindAction {
             Self::ZoomIn => Some(Action::ZoomIn),
             Self::ZoomOut => Some(Action::ZoomOut),
             Self::ZoomReset => Some(Action::ZoomReset),
+            Self::ScrollToTop => Some(Action::ScrollToTop),
+            Self::ScrollToBottom => Some(Action::ScrollToBottom),
+            Self::ScrollPageUp => Some(Action::ScrollPageUp),
+            Self::ScrollPageDown => Some(Action::ScrollPageDown),
             Self::PasswordManager => {
                 #[cfg(feature = "password_manager")]
                 {
@@ -294,6 +302,10 @@ pub fn action_label(action: KeyBindAction) -> String {
         KeyBindAction::ZoomIn => fl!("zoom-in"),
         KeyBindAction::ZoomOut => fl!("zoom-out"),
         KeyBindAction::ZoomReset => fl!("zoom-reset"),
+        KeyBindAction::ScrollToTop => fl!("scroll-to-top"),
+        KeyBindAction::ScrollToBottom => fl!("scroll-to-bottom"),
+        KeyBindAction::ScrollPageUp => fl!("scroll-page-up"),
+        KeyBindAction::ScrollPageDown => fl!("scroll-page-down"),
     }
 }
 
@@ -362,7 +374,13 @@ pub fn shortcut_groups() -> Vec<ShortcutGroup> {
             KeyBindAction::ZoomReset,
         ],
     });
-    let mut other_actions = vec![KeyBindAction::ClearScrollback];
+    let mut other_actions = vec![
+        KeyBindAction::ClearScrollback,
+        KeyBindAction::ScrollToTop,
+        KeyBindAction::ScrollToBottom,
+        KeyBindAction::ScrollPageUp,
+        KeyBindAction::ScrollPageDown,
+    ];
     #[cfg(feature = "password_manager")]
     other_actions.push(KeyBindAction::PasswordManager);
     groups.push(ShortcutGroup {
@@ -499,6 +517,14 @@ fn fallback_shortcuts() -> Shortcuts {
 
     // CTRL+Alt+L clears the scrollback.
     bind!([Ctrl, Alt], "L", ClearScrollback);
+
+    // Shift+Home/End jump to the top/bottom of the scrollback.
+    bind!([Shift], "Home", ScrollToTop);
+    bind!([Shift], "End", ScrollToBottom);
+
+    // Shift+PageUp/PageDown scroll the scrollback by a page.
+    bind!([Shift], "PageUp", ScrollPageUp);
+    bind!([Shift], "PageDown", ScrollPageDown);
 
     Shortcuts(shortcuts)
 }

--- a/src/terminal_box.rs
+++ b/src/terminal_box.rs
@@ -959,22 +959,8 @@ where
                 let escape_code = match named {
                     Named::Insert => csi("2", "~", mod_no),
                     Named::Delete => csi("3", "~", mod_no),
-                    Named::PageUp => {
-                        if modifiers.shift() {
-                            terminal.scroll(TerminalScroll::PageUp);
-                            None
-                        } else {
-                            csi("5", "~", mod_no)
-                        }
-                    }
-                    Named::PageDown => {
-                        if modifiers.shift() {
-                            terminal.scroll(TerminalScroll::PageDown);
-                            None
-                        } else {
-                            csi("6", "~", mod_no)
-                        }
-                    }
+                    Named::PageUp => csi("5", "~", mod_no),
+                    Named::PageDown => csi("6", "~", mod_no),
                     Named::ArrowUp => {
                         if is_app_cursor {
                             ss3("A", mod_no)
@@ -1004,20 +990,14 @@ where
                         }
                     }
                     Named::End => {
-                        if modifiers.shift() {
-                            terminal.scroll(TerminalScroll::Bottom);
-                            None
-                        } else if is_app_cursor {
+                        if is_app_cursor {
                             ss3("F", mod_no)
                         } else {
                             csi2("F", mod_no)
                         }
                     }
                     Named::Home => {
-                        if modifiers.shift() {
-                            terminal.scroll(TerminalScroll::Top);
-                            None
-                        } else if is_app_cursor {
+                        if is_app_cursor {
                             ss3("H", mod_no)
                         } else {
                             csi2("H", mod_no)


### PR DESCRIPTION
## Summary

This allows users to disable them if they want the key combination to be passed through to the shell instead.

## Testing

* Use the following to output some junk to the terminal: `perl -e 'foreach (0 .. 100) { print rand() . "\n"; }'`
* See that ordinarily, Shift+PageUp/PageDown and Shift+Home/End move the scroll as usual
* Go to keybind settings and delete the keybinds
* See that now, the keys are passed through to the ty (this sequence is pressing shift+home/end then shift+pageup/pagedown):

```
jude@host:~  $ cat -v
^[[1;2H^[[1;2F^[[5;2~^[[6;2~
```

## Addendum

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

